### PR TITLE
Respect dependency files

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -27,6 +27,7 @@ _exclude:
   - /vendor
 
 _skip_if_exists:
+  - odoo/custom/dependencies/*.txt
   - odoo/custom/src/addons.yaml
   - odoo/custom/src/repos.yaml
   - odoo/custom/src/private/*/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def teardown_function(function):
+    pre_commit_log = (
+        Path("~") / ".cache" / "pre-commit" / "pre-commit.log"
+    ).expanduser()
+    if pre_commit_log.is_file():
+        print(pre_commit_log.read_text())
+        pre_commit_log.unlink()


### PR DESCRIPTION
Dependency files should be ignored if present; we don't want to alter them if user has modified them.

@Tecnativa TT20357