### PR TITLE
Use invoke binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ This project itself is just the template, but you need to install these tools to
 
 - [copier][] v3.0.0a6 or newer
 - [git](https://git-scm.com/)
-- [invoke](https://www.pyinvoke.org/) (`python3 -m pip install --user invoke`)
+- [invoke](https://www.pyinvoke.org/) installed in Python 3.6+ (and the binary must be
+  called `invoke`).
 - [pre-commit](https://pre-commit.com/)
 - [python](https://www.python.org/) 3.6+
 

--- a/copier.yml
+++ b/copier.yml
@@ -32,7 +32,7 @@ _skip_if_exists:
   - odoo/custom/src/private/*/
 
 _tasks:
-  - python3 -m invoke develop
+  - invoke develop
 
 # Questions for the user
 project_name:


### PR DESCRIPTION
Calling it with `python3 -m` makes it run in the same venv as copier itself.

Copier doesn't depend on invoke, and it could be installed isolated with `pipx` or similar tools, where invoke wouldn't be available. OTOH invoke itself could be installed with `pipx`, so it's better to just use the binary.

It has the con that in some distros `invoke` will be the py2 version. I warn about the binary name in the README.

@Tecnativa TT20357