### PR TITLE
Revert "Autoremove automerge label"

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -25,5 +25,4 @@ jobs:
           MERGE_DELETE_BRANCH: "true"
           MERGE_LABELS: "automerge,!work in progress"
           MERGE_METHOD: "rebase"
-          MERGE_REMOVE_LABELS: "automerge"
           UPDATE_METHOD: "rebase"


### PR DESCRIPTION
Reverts Tecnativa/doodba-copier-template#4 due to https://github.com/pascalgn/automerge-action/issues/56 making that label disappear from repo.