### PR TITLE
Update pre-commit to Prettier 2

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -24,19 +24,16 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/prettier/prettier
-    rev: "1.19.1"
+    rev: 2.0.2
     hooks:
-      - id: prettier
-  # TODO Avoid awebdeveloper/pre-commit-prettier if possible
-  # HACK https://github.com/prettier/prettier/issues/7407
-  - repo: https://github.com/awebdeveloper/pre-commit-prettier
-    rev: v0.0.1
-    hooks:
-      - id: prettier
-        name: prettier xml plugin
+      - &prettier
+        id: prettier
         additional_dependencies:
-          - "prettier@1.19.1"
           - "@prettier/plugin-xml@0.7.2"
+        args:
+          - --plugin=@prettier/plugin-xml
+      - <<: *prettier
+        name: prettier + plugin-xml
         files: \.xml$
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v6.8.0
@@ -47,7 +44,7 @@ repos:
           - --color
           - --fix
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -91,7 +88,7 @@ repos:
           - --rcfile=.pylintrc-mandatory
         additional_dependencies: ["pylint-odoo==3.1.0"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.1.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/timothycrosley/isort

--- a/tests/default_settings/v10.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v10.0/.pre-commit-config.yaml
@@ -21,19 +21,16 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/prettier/prettier
-    rev: "1.19.1"
+    rev: 2.0.2
     hooks:
-      - id: prettier
-  # TODO Avoid awebdeveloper/pre-commit-prettier if possible
-  # HACK https://github.com/prettier/prettier/issues/7407
-  - repo: https://github.com/awebdeveloper/pre-commit-prettier
-    rev: v0.0.1
-    hooks:
-      - id: prettier
-        name: prettier xml plugin
+      - &prettier
+        id: prettier
         additional_dependencies:
-          - "prettier@1.19.1"
           - "@prettier/plugin-xml@0.7.2"
+        args:
+          - --plugin=@prettier/plugin-xml
+      - <<: *prettier
+        name: prettier + plugin-xml
         files: \.xml$
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v6.8.0
@@ -44,7 +41,7 @@ repos:
           - --color
           - --fix
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -85,7 +82,7 @@ repos:
           - --rcfile=.pylintrc-mandatory
         additional_dependencies: ["pylint-odoo==3.1.0"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.1.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/timothycrosley/isort

--- a/tests/default_settings/v11.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v11.0/.pre-commit-config.yaml
@@ -21,19 +21,16 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/prettier/prettier
-    rev: "1.19.1"
+    rev: 2.0.2
     hooks:
-      - id: prettier
-  # TODO Avoid awebdeveloper/pre-commit-prettier if possible
-  # HACK https://github.com/prettier/prettier/issues/7407
-  - repo: https://github.com/awebdeveloper/pre-commit-prettier
-    rev: v0.0.1
-    hooks:
-      - id: prettier
-        name: prettier xml plugin
+      - &prettier
+        id: prettier
         additional_dependencies:
-          - "prettier@1.19.1"
           - "@prettier/plugin-xml@0.7.2"
+        args:
+          - --plugin=@prettier/plugin-xml
+      - <<: *prettier
+        name: prettier + plugin-xml
         files: \.xml$
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v6.8.0
@@ -44,7 +41,7 @@ repos:
           - --color
           - --fix
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -86,7 +83,7 @@ repos:
           - --rcfile=.pylintrc-mandatory
         additional_dependencies: ["pylint-odoo==3.1.0"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.1.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/timothycrosley/isort

--- a/tests/default_settings/v12.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v12.0/.pre-commit-config.yaml
@@ -21,19 +21,16 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/prettier/prettier
-    rev: "1.19.1"
+    rev: 2.0.2
     hooks:
-      - id: prettier
-  # TODO Avoid awebdeveloper/pre-commit-prettier if possible
-  # HACK https://github.com/prettier/prettier/issues/7407
-  - repo: https://github.com/awebdeveloper/pre-commit-prettier
-    rev: v0.0.1
-    hooks:
-      - id: prettier
-        name: prettier xml plugin
+      - &prettier
+        id: prettier
         additional_dependencies:
-          - "prettier@1.19.1"
           - "@prettier/plugin-xml@0.7.2"
+        args:
+          - --plugin=@prettier/plugin-xml
+      - <<: *prettier
+        name: prettier + plugin-xml
         files: \.xml$
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v6.8.0
@@ -44,7 +41,7 @@ repos:
           - --color
           - --fix
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -86,7 +83,7 @@ repos:
           - --rcfile=.pylintrc-mandatory
         additional_dependencies: ["pylint-odoo==3.1.0"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.1.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/timothycrosley/isort

--- a/tests/default_settings/v13.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v13.0/.pre-commit-config.yaml
@@ -21,19 +21,16 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/prettier/prettier
-    rev: "1.19.1"
+    rev: 2.0.2
     hooks:
-      - id: prettier
-  # TODO Avoid awebdeveloper/pre-commit-prettier if possible
-  # HACK https://github.com/prettier/prettier/issues/7407
-  - repo: https://github.com/awebdeveloper/pre-commit-prettier
-    rev: v0.0.1
-    hooks:
-      - id: prettier
-        name: prettier xml plugin
+      - &prettier
+        id: prettier
         additional_dependencies:
-          - "prettier@1.19.1"
           - "@prettier/plugin-xml@0.7.2"
+        args:
+          - --plugin=@prettier/plugin-xml
+      - <<: *prettier
+        name: prettier + plugin-xml
         files: \.xml$
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v6.8.0
@@ -44,7 +41,7 @@ repos:
           - --color
           - --fix
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -86,7 +83,7 @@ repos:
           - --rcfile=.pylintrc-mandatory
         additional_dependencies: ["pylint-odoo==3.1.0"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.1.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/timothycrosley/isort

--- a/tests/default_settings/v7.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v7.0/.pre-commit-config.yaml
@@ -21,19 +21,16 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/prettier/prettier
-    rev: "1.19.1"
+    rev: 2.0.2
     hooks:
-      - id: prettier
-  # TODO Avoid awebdeveloper/pre-commit-prettier if possible
-  # HACK https://github.com/prettier/prettier/issues/7407
-  - repo: https://github.com/awebdeveloper/pre-commit-prettier
-    rev: v0.0.1
-    hooks:
-      - id: prettier
-        name: prettier xml plugin
+      - &prettier
+        id: prettier
         additional_dependencies:
-          - "prettier@1.19.1"
           - "@prettier/plugin-xml@0.7.2"
+        args:
+          - --plugin=@prettier/plugin-xml
+      - <<: *prettier
+        name: prettier + plugin-xml
         files: \.xml$
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v6.8.0
@@ -44,7 +41,7 @@ repos:
           - --color
           - --fix
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -85,7 +82,7 @@ repos:
           - --rcfile=.pylintrc-mandatory
         additional_dependencies: ["pylint-odoo==3.1.0"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.1.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/timothycrosley/isort

--- a/tests/default_settings/v8.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v8.0/.pre-commit-config.yaml
@@ -21,19 +21,16 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/prettier/prettier
-    rev: "1.19.1"
+    rev: 2.0.2
     hooks:
-      - id: prettier
-  # TODO Avoid awebdeveloper/pre-commit-prettier if possible
-  # HACK https://github.com/prettier/prettier/issues/7407
-  - repo: https://github.com/awebdeveloper/pre-commit-prettier
-    rev: v0.0.1
-    hooks:
-      - id: prettier
-        name: prettier xml plugin
+      - &prettier
+        id: prettier
         additional_dependencies:
-          - "prettier@1.19.1"
           - "@prettier/plugin-xml@0.7.2"
+        args:
+          - --plugin=@prettier/plugin-xml
+      - <<: *prettier
+        name: prettier + plugin-xml
         files: \.xml$
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v6.8.0
@@ -44,7 +41,7 @@ repos:
           - --color
           - --fix
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -85,7 +82,7 @@ repos:
           - --rcfile=.pylintrc-mandatory
         additional_dependencies: ["pylint-odoo==3.1.0"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.1.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/timothycrosley/isort

--- a/tests/default_settings/v9.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v9.0/.pre-commit-config.yaml
@@ -21,19 +21,16 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/prettier/prettier
-    rev: "1.19.1"
+    rev: 2.0.2
     hooks:
-      - id: prettier
-  # TODO Avoid awebdeveloper/pre-commit-prettier if possible
-  # HACK https://github.com/prettier/prettier/issues/7407
-  - repo: https://github.com/awebdeveloper/pre-commit-prettier
-    rev: v0.0.1
-    hooks:
-      - id: prettier
-        name: prettier xml plugin
+      - &prettier
+        id: prettier
         additional_dependencies:
-          - "prettier@1.19.1"
           - "@prettier/plugin-xml@0.7.2"
+        args:
+          - --plugin=@prettier/plugin-xml
+      - <<: *prettier
+        name: prettier + plugin-xml
         files: \.xml$
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v6.8.0
@@ -44,7 +41,7 @@ repos:
           - --color
           - --fix
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -85,7 +82,7 @@ repos:
           - --rcfile=.pylintrc-mandatory
         additional_dependencies: ["pylint-odoo==3.1.0"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.1.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/timothycrosley/isort


### PR DESCRIPTION
Prettier 2 supports plugins, so it's better than using a random external repo.

Follows https://github.com/OCA/maintainer-quality-tools/pull/655#discussion_r399971845.

Also update some other hooks and MQT.