### PR TITLE
Add traefik 2 support

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -49,7 +49,10 @@ _migrations:
 # Questions for the user
 project_name:
   type: str
-  help: What's your project name?
+  help: >-
+    What's your project name?
+
+    Do not use dots or spaces in the name; just "A-Za-z0-9-_" please.
   default: myproject-odoo
 
 project_license:

--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -1,3 +1,4 @@
+{% set _key = '%s-%.1f-prod'|format(project_name, odoo_version)|replace('.', '-') %}
 version: "2.4"
 
 services:
@@ -34,6 +35,32 @@ services:
       traefik.alt-{{ loop.index0 }}.frontend.rule: "Host:${DOMAIN_PROD_ALT_{{ loop.index0 }}}"
       {%- endfor %}
       {%- endif %}
+      # Main service
+      traefik.http.middlewares.{{ _key }}-main-buffering.buffering.retryExpression: "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.{{ _key }}-main-compress.compress: "true"
+      traefik.http.routers.{{ _key }}-main.entrypoints: "web-main"
+      traefik.http.routers.{{ _key }}-main.middlewares: "{{ _key }}-main-compress,{{ _key }}-main-buffering"
+      traefik.http.routers.{{ _key }}-main.rule: "host(`${DOMAIN_PROD}`)"
+      traefik.http.routers.{{ _key }}-main.service: "{{ _key }}-main"
+      traefik.http.routers.{{ _key }}-main.tls: "true"
+      traefik.http.routers.{{ _key }}-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.{{ _key }}-main.loadbalancer.server.port: 8069
+      # Redirect alternative domains to main domain
+      traefik.http.middlewares.{{ _key }}-redirect2main.redirectregex.regex: "^https://([^/]+)/(.*)$$"
+      traefik.http.middlewares.{{ _key }}-redirect2main.redirectregex.replacement: "https://${DOMAIN_PROD}/$${2}"
+      traefik.http.routers.{{ _key }}-altdomains.entrypoints: "web-main"
+      traefik.http.routers.{{ _key }}-altdomains.middlewares: "{{ _key }}-redirect2main"
+      traefik.http.routers.{{ _key }}-altdomains.rule: "host(`${DOMAIN_PROD_ALT}`)"
+      traefik.http.routers.{{ _key }}-altdomains.service: "{{ _key }}-main"
+      traefik.http.routers.{{ _key }}-altdomains.tls: "true"
+      traefik.http.routers.{{ _key }}-altdomains.tls.certresolver: "letsencrypt"
+      # Longpolling service
+      traefik.http.routers.{{ _key }}-longpolling.entrypoints: "web-main"
+      traefik.http.routers.{{ _key }}-longpolling.rule: "host(`${DOMAIN_PROD}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.{{ _key }}-longpolling.service: "{{ _key }}-longpolling"
+      traefik.http.services.{{ _key }}-longpolling.loadbalancer.server.port: 8072
+      traefik.http.routers.{{ _key }}-longpolling.tls: "true"
+      traefik.http.routers.{{ _key }}-longpolling.tls.certresolver: "letsencrypt"
     {%- endif %}
 
   db:

--- a/test.yaml.jinja
+++ b/test.yaml.jinja
@@ -1,3 +1,4 @@
+{% set _key = '%s-%.1f-test'|format(project_name, odoo_version)|replace('.', '-') %}
 version: "2.4"
 
 services:
@@ -27,6 +28,22 @@ services:
       traefik.frontend.headers.customResponseHeaders: "X-Robots-Tag:noindex, nofollow"
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_TEST};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
+      # Main service
+      traefik.http.middlewares.{{ _key }}-main-buffering.buffering.retryExpression: "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.{{ _key }}-main-compress.compress: "true"
+      traefik.http.routers.{{ _key }}-main.entrypoints: "web-main"
+      traefik.http.routers.{{ _key }}-main.middlewares: "{{ _key }}-main-compress,{{ _key }}-main-buffering"
+      traefik.http.routers.{{ _key }}-main.rule: "host(`${DOMAIN_TEST}`)"
+      traefik.http.routers.{{ _key }}-main.service: "{{ _key }}-main"
+      traefik.http.routers.{{ _key }}-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.{{ _key }}-main.loadbalancer.server.port: 8069
+      # Longpolling service
+      traefik.http.routers.{{ _key }}-longpolling.entrypoints: "web-main"
+      traefik.http.routers.{{ _key }}-longpolling.rule: "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.{{ _key }}-longpolling.service: "{{ _key }}-longpolling"
+      traefik.http.routers.{{ _key }}-longpolling.tls: "true"
+      traefik.http.routers.{{ _key }}-longpolling.tls.certresolver: "letsencrypt"
+      traefik.http.services.{{ _key }}-longpolling.loadbalancer.server.port: 8072
     {%- endif %}
     command:
       - odoo

--- a/tests/default_settings/v10.0/prod.yaml
+++ b/tests/default_settings/v10.0/prod.yaml
@@ -20,6 +20,34 @@ services:
     labels:
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_PROD};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_PROD}"
+      # Main service
+      ? traefik.http.middlewares.myproject-odoo-10-0-prod-main-buffering.buffering.retryExpression
+      : "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.myproject-odoo-10-0-prod-main-compress.compress: "true"
+      traefik.http.routers.myproject-odoo-10-0-prod-main.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-10-0-prod-main.middlewares: "myproject-odoo-10-0-prod-main-compress,myproject-odoo-10-0-prod-main-buffering"
+      traefik.http.routers.myproject-odoo-10-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
+      traefik.http.routers.myproject-odoo-10-0-prod-main.service: "myproject-odoo-10-0-prod-main"
+      traefik.http.routers.myproject-odoo-10-0-prod-main.tls: "true"
+      traefik.http.routers.myproject-odoo-10-0-prod-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-10-0-prod-main.loadbalancer.server.port: 8069
+      # Redirect alternative domains to main domain
+      traefik.http.middlewares.myproject-odoo-10-0-prod-redirect2main.redirectregex.regex: "^https://([^/]+)/(.*)$$"
+      traefik.http.middlewares.myproject-odoo-10-0-prod-redirect2main.redirectregex.replacement: "https://${DOMAIN_PROD}/$${2}"
+      traefik.http.routers.myproject-odoo-10-0-prod-altdomains.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-10-0-prod-altdomains.middlewares: "myproject-odoo-10-0-prod-redirect2main"
+      traefik.http.routers.myproject-odoo-10-0-prod-altdomains.rule: "host(`${DOMAIN_PROD_ALT}`)"
+      traefik.http.routers.myproject-odoo-10-0-prod-altdomains.service: "myproject-odoo-10-0-prod-main"
+      traefik.http.routers.myproject-odoo-10-0-prod-altdomains.tls: "true"
+      traefik.http.routers.myproject-odoo-10-0-prod-altdomains.tls.certresolver: "letsencrypt"
+      # Longpolling service
+      traefik.http.routers.myproject-odoo-10-0-prod-longpolling.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-10-0-prod-longpolling.rule:
+        "host(`${DOMAIN_PROD}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.myproject-odoo-10-0-prod-longpolling.service: "myproject-odoo-10-0-prod-longpolling"
+      traefik.http.services.myproject-odoo-10-0-prod-longpolling.loadbalancer.server.port: 8072
+      traefik.http.routers.myproject-odoo-10-0-prod-longpolling.tls: "true"
+      traefik.http.routers.myproject-odoo-10-0-prod-longpolling.tls.certresolver: "letsencrypt"
 
   db:
     extends:

--- a/tests/default_settings/v10.0/test.yaml
+++ b/tests/default_settings/v10.0/test.yaml
@@ -26,6 +26,24 @@ services:
       traefik.frontend.headers.customResponseHeaders: "X-Robots-Tag:noindex, nofollow"
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_TEST};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
+      # Main service
+      ? traefik.http.middlewares.myproject-odoo-10-0-test-main-buffering.buffering.retryExpression
+      : "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.myproject-odoo-10-0-test-main-compress.compress: "true"
+      traefik.http.routers.myproject-odoo-10-0-test-main.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-10-0-test-main.middlewares: "myproject-odoo-10-0-test-main-compress,myproject-odoo-10-0-test-main-buffering"
+      traefik.http.routers.myproject-odoo-10-0-test-main.rule: "host(`${DOMAIN_TEST}`)"
+      traefik.http.routers.myproject-odoo-10-0-test-main.service: "myproject-odoo-10-0-test-main"
+      traefik.http.routers.myproject-odoo-10-0-test-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-10-0-test-main.loadbalancer.server.port: 8069
+      # Longpolling service
+      traefik.http.routers.myproject-odoo-10-0-test-longpolling.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-10-0-test-longpolling.rule:
+        "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.myproject-odoo-10-0-test-longpolling.service: "myproject-odoo-10-0-test-longpolling"
+      traefik.http.routers.myproject-odoo-10-0-test-longpolling.tls: "true"
+      traefik.http.routers.myproject-odoo-10-0-test-longpolling.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-10-0-test-longpolling.loadbalancer.server.port: 8072
     command:
       - odoo
       - --workers=2

--- a/tests/default_settings/v11.0/prod.yaml
+++ b/tests/default_settings/v11.0/prod.yaml
@@ -20,6 +20,34 @@ services:
     labels:
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_PROD};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_PROD}"
+      # Main service
+      ? traefik.http.middlewares.myproject-odoo-11-0-prod-main-buffering.buffering.retryExpression
+      : "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.myproject-odoo-11-0-prod-main-compress.compress: "true"
+      traefik.http.routers.myproject-odoo-11-0-prod-main.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-11-0-prod-main.middlewares: "myproject-odoo-11-0-prod-main-compress,myproject-odoo-11-0-prod-main-buffering"
+      traefik.http.routers.myproject-odoo-11-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
+      traefik.http.routers.myproject-odoo-11-0-prod-main.service: "myproject-odoo-11-0-prod-main"
+      traefik.http.routers.myproject-odoo-11-0-prod-main.tls: "true"
+      traefik.http.routers.myproject-odoo-11-0-prod-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-11-0-prod-main.loadbalancer.server.port: 8069
+      # Redirect alternative domains to main domain
+      traefik.http.middlewares.myproject-odoo-11-0-prod-redirect2main.redirectregex.regex: "^https://([^/]+)/(.*)$$"
+      traefik.http.middlewares.myproject-odoo-11-0-prod-redirect2main.redirectregex.replacement: "https://${DOMAIN_PROD}/$${2}"
+      traefik.http.routers.myproject-odoo-11-0-prod-altdomains.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-11-0-prod-altdomains.middlewares: "myproject-odoo-11-0-prod-redirect2main"
+      traefik.http.routers.myproject-odoo-11-0-prod-altdomains.rule: "host(`${DOMAIN_PROD_ALT}`)"
+      traefik.http.routers.myproject-odoo-11-0-prod-altdomains.service: "myproject-odoo-11-0-prod-main"
+      traefik.http.routers.myproject-odoo-11-0-prod-altdomains.tls: "true"
+      traefik.http.routers.myproject-odoo-11-0-prod-altdomains.tls.certresolver: "letsencrypt"
+      # Longpolling service
+      traefik.http.routers.myproject-odoo-11-0-prod-longpolling.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-11-0-prod-longpolling.rule:
+        "host(`${DOMAIN_PROD}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.myproject-odoo-11-0-prod-longpolling.service: "myproject-odoo-11-0-prod-longpolling"
+      traefik.http.services.myproject-odoo-11-0-prod-longpolling.loadbalancer.server.port: 8072
+      traefik.http.routers.myproject-odoo-11-0-prod-longpolling.tls: "true"
+      traefik.http.routers.myproject-odoo-11-0-prod-longpolling.tls.certresolver: "letsencrypt"
 
   db:
     extends:

--- a/tests/default_settings/v11.0/test.yaml
+++ b/tests/default_settings/v11.0/test.yaml
@@ -26,6 +26,24 @@ services:
       traefik.frontend.headers.customResponseHeaders: "X-Robots-Tag:noindex, nofollow"
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_TEST};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
+      # Main service
+      ? traefik.http.middlewares.myproject-odoo-11-0-test-main-buffering.buffering.retryExpression
+      : "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.myproject-odoo-11-0-test-main-compress.compress: "true"
+      traefik.http.routers.myproject-odoo-11-0-test-main.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-11-0-test-main.middlewares: "myproject-odoo-11-0-test-main-compress,myproject-odoo-11-0-test-main-buffering"
+      traefik.http.routers.myproject-odoo-11-0-test-main.rule: "host(`${DOMAIN_TEST}`)"
+      traefik.http.routers.myproject-odoo-11-0-test-main.service: "myproject-odoo-11-0-test-main"
+      traefik.http.routers.myproject-odoo-11-0-test-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-11-0-test-main.loadbalancer.server.port: 8069
+      # Longpolling service
+      traefik.http.routers.myproject-odoo-11-0-test-longpolling.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-11-0-test-longpolling.rule:
+        "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.myproject-odoo-11-0-test-longpolling.service: "myproject-odoo-11-0-test-longpolling"
+      traefik.http.routers.myproject-odoo-11-0-test-longpolling.tls: "true"
+      traefik.http.routers.myproject-odoo-11-0-test-longpolling.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-11-0-test-longpolling.loadbalancer.server.port: 8072
     command:
       - odoo
       - --workers=2

--- a/tests/default_settings/v12.0/prod.yaml
+++ b/tests/default_settings/v12.0/prod.yaml
@@ -20,6 +20,34 @@ services:
     labels:
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_PROD};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_PROD}"
+      # Main service
+      ? traefik.http.middlewares.myproject-odoo-12-0-prod-main-buffering.buffering.retryExpression
+      : "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.myproject-odoo-12-0-prod-main-compress.compress: "true"
+      traefik.http.routers.myproject-odoo-12-0-prod-main.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-12-0-prod-main.middlewares: "myproject-odoo-12-0-prod-main-compress,myproject-odoo-12-0-prod-main-buffering"
+      traefik.http.routers.myproject-odoo-12-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
+      traefik.http.routers.myproject-odoo-12-0-prod-main.service: "myproject-odoo-12-0-prod-main"
+      traefik.http.routers.myproject-odoo-12-0-prod-main.tls: "true"
+      traefik.http.routers.myproject-odoo-12-0-prod-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-12-0-prod-main.loadbalancer.server.port: 8069
+      # Redirect alternative domains to main domain
+      traefik.http.middlewares.myproject-odoo-12-0-prod-redirect2main.redirectregex.regex: "^https://([^/]+)/(.*)$$"
+      traefik.http.middlewares.myproject-odoo-12-0-prod-redirect2main.redirectregex.replacement: "https://${DOMAIN_PROD}/$${2}"
+      traefik.http.routers.myproject-odoo-12-0-prod-altdomains.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-12-0-prod-altdomains.middlewares: "myproject-odoo-12-0-prod-redirect2main"
+      traefik.http.routers.myproject-odoo-12-0-prod-altdomains.rule: "host(`${DOMAIN_PROD_ALT}`)"
+      traefik.http.routers.myproject-odoo-12-0-prod-altdomains.service: "myproject-odoo-12-0-prod-main"
+      traefik.http.routers.myproject-odoo-12-0-prod-altdomains.tls: "true"
+      traefik.http.routers.myproject-odoo-12-0-prod-altdomains.tls.certresolver: "letsencrypt"
+      # Longpolling service
+      traefik.http.routers.myproject-odoo-12-0-prod-longpolling.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-12-0-prod-longpolling.rule:
+        "host(`${DOMAIN_PROD}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.myproject-odoo-12-0-prod-longpolling.service: "myproject-odoo-12-0-prod-longpolling"
+      traefik.http.services.myproject-odoo-12-0-prod-longpolling.loadbalancer.server.port: 8072
+      traefik.http.routers.myproject-odoo-12-0-prod-longpolling.tls: "true"
+      traefik.http.routers.myproject-odoo-12-0-prod-longpolling.tls.certresolver: "letsencrypt"
 
   db:
     extends:

--- a/tests/default_settings/v12.0/test.yaml
+++ b/tests/default_settings/v12.0/test.yaml
@@ -26,6 +26,24 @@ services:
       traefik.frontend.headers.customResponseHeaders: "X-Robots-Tag:noindex, nofollow"
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_TEST};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
+      # Main service
+      ? traefik.http.middlewares.myproject-odoo-12-0-test-main-buffering.buffering.retryExpression
+      : "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.myproject-odoo-12-0-test-main-compress.compress: "true"
+      traefik.http.routers.myproject-odoo-12-0-test-main.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-12-0-test-main.middlewares: "myproject-odoo-12-0-test-main-compress,myproject-odoo-12-0-test-main-buffering"
+      traefik.http.routers.myproject-odoo-12-0-test-main.rule: "host(`${DOMAIN_TEST}`)"
+      traefik.http.routers.myproject-odoo-12-0-test-main.service: "myproject-odoo-12-0-test-main"
+      traefik.http.routers.myproject-odoo-12-0-test-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-12-0-test-main.loadbalancer.server.port: 8069
+      # Longpolling service
+      traefik.http.routers.myproject-odoo-12-0-test-longpolling.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-12-0-test-longpolling.rule:
+        "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.myproject-odoo-12-0-test-longpolling.service: "myproject-odoo-12-0-test-longpolling"
+      traefik.http.routers.myproject-odoo-12-0-test-longpolling.tls: "true"
+      traefik.http.routers.myproject-odoo-12-0-test-longpolling.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-12-0-test-longpolling.loadbalancer.server.port: 8072
     command:
       - odoo
       - --workers=2

--- a/tests/default_settings/v13.0/prod.yaml
+++ b/tests/default_settings/v13.0/prod.yaml
@@ -20,6 +20,34 @@ services:
     labels:
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_PROD};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_PROD}"
+      # Main service
+      ? traefik.http.middlewares.myproject-odoo-13-0-prod-main-buffering.buffering.retryExpression
+      : "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.myproject-odoo-13-0-prod-main-compress.compress: "true"
+      traefik.http.routers.myproject-odoo-13-0-prod-main.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-13-0-prod-main.middlewares: "myproject-odoo-13-0-prod-main-compress,myproject-odoo-13-0-prod-main-buffering"
+      traefik.http.routers.myproject-odoo-13-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
+      traefik.http.routers.myproject-odoo-13-0-prod-main.service: "myproject-odoo-13-0-prod-main"
+      traefik.http.routers.myproject-odoo-13-0-prod-main.tls: "true"
+      traefik.http.routers.myproject-odoo-13-0-prod-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-13-0-prod-main.loadbalancer.server.port: 8069
+      # Redirect alternative domains to main domain
+      traefik.http.middlewares.myproject-odoo-13-0-prod-redirect2main.redirectregex.regex: "^https://([^/]+)/(.*)$$"
+      traefik.http.middlewares.myproject-odoo-13-0-prod-redirect2main.redirectregex.replacement: "https://${DOMAIN_PROD}/$${2}"
+      traefik.http.routers.myproject-odoo-13-0-prod-altdomains.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-13-0-prod-altdomains.middlewares: "myproject-odoo-13-0-prod-redirect2main"
+      traefik.http.routers.myproject-odoo-13-0-prod-altdomains.rule: "host(`${DOMAIN_PROD_ALT}`)"
+      traefik.http.routers.myproject-odoo-13-0-prod-altdomains.service: "myproject-odoo-13-0-prod-main"
+      traefik.http.routers.myproject-odoo-13-0-prod-altdomains.tls: "true"
+      traefik.http.routers.myproject-odoo-13-0-prod-altdomains.tls.certresolver: "letsencrypt"
+      # Longpolling service
+      traefik.http.routers.myproject-odoo-13-0-prod-longpolling.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-13-0-prod-longpolling.rule:
+        "host(`${DOMAIN_PROD}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.myproject-odoo-13-0-prod-longpolling.service: "myproject-odoo-13-0-prod-longpolling"
+      traefik.http.services.myproject-odoo-13-0-prod-longpolling.loadbalancer.server.port: 8072
+      traefik.http.routers.myproject-odoo-13-0-prod-longpolling.tls: "true"
+      traefik.http.routers.myproject-odoo-13-0-prod-longpolling.tls.certresolver: "letsencrypt"
 
   db:
     extends:

--- a/tests/default_settings/v13.0/test.yaml
+++ b/tests/default_settings/v13.0/test.yaml
@@ -26,6 +26,24 @@ services:
       traefik.frontend.headers.customResponseHeaders: "X-Robots-Tag:noindex, nofollow"
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_TEST};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
+      # Main service
+      ? traefik.http.middlewares.myproject-odoo-13-0-test-main-buffering.buffering.retryExpression
+      : "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.myproject-odoo-13-0-test-main-compress.compress: "true"
+      traefik.http.routers.myproject-odoo-13-0-test-main.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-13-0-test-main.middlewares: "myproject-odoo-13-0-test-main-compress,myproject-odoo-13-0-test-main-buffering"
+      traefik.http.routers.myproject-odoo-13-0-test-main.rule: "host(`${DOMAIN_TEST}`)"
+      traefik.http.routers.myproject-odoo-13-0-test-main.service: "myproject-odoo-13-0-test-main"
+      traefik.http.routers.myproject-odoo-13-0-test-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-13-0-test-main.loadbalancer.server.port: 8069
+      # Longpolling service
+      traefik.http.routers.myproject-odoo-13-0-test-longpolling.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-13-0-test-longpolling.rule:
+        "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.myproject-odoo-13-0-test-longpolling.service: "myproject-odoo-13-0-test-longpolling"
+      traefik.http.routers.myproject-odoo-13-0-test-longpolling.tls: "true"
+      traefik.http.routers.myproject-odoo-13-0-test-longpolling.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-13-0-test-longpolling.loadbalancer.server.port: 8072
     command:
       - odoo
       - --workers=2

--- a/tests/default_settings/v7.0/prod.yaml
+++ b/tests/default_settings/v7.0/prod.yaml
@@ -20,6 +20,34 @@ services:
     labels:
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_PROD};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_PROD}"
+      # Main service
+      ? traefik.http.middlewares.myproject-odoo-7-0-prod-main-buffering.buffering.retryExpression
+      : "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.myproject-odoo-7-0-prod-main-compress.compress: "true"
+      traefik.http.routers.myproject-odoo-7-0-prod-main.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-7-0-prod-main.middlewares: "myproject-odoo-7-0-prod-main-compress,myproject-odoo-7-0-prod-main-buffering"
+      traefik.http.routers.myproject-odoo-7-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
+      traefik.http.routers.myproject-odoo-7-0-prod-main.service: "myproject-odoo-7-0-prod-main"
+      traefik.http.routers.myproject-odoo-7-0-prod-main.tls: "true"
+      traefik.http.routers.myproject-odoo-7-0-prod-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-7-0-prod-main.loadbalancer.server.port: 8069
+      # Redirect alternative domains to main domain
+      traefik.http.middlewares.myproject-odoo-7-0-prod-redirect2main.redirectregex.regex: "^https://([^/]+)/(.*)$$"
+      traefik.http.middlewares.myproject-odoo-7-0-prod-redirect2main.redirectregex.replacement: "https://${DOMAIN_PROD}/$${2}"
+      traefik.http.routers.myproject-odoo-7-0-prod-altdomains.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-7-0-prod-altdomains.middlewares: "myproject-odoo-7-0-prod-redirect2main"
+      traefik.http.routers.myproject-odoo-7-0-prod-altdomains.rule: "host(`${DOMAIN_PROD_ALT}`)"
+      traefik.http.routers.myproject-odoo-7-0-prod-altdomains.service: "myproject-odoo-7-0-prod-main"
+      traefik.http.routers.myproject-odoo-7-0-prod-altdomains.tls: "true"
+      traefik.http.routers.myproject-odoo-7-0-prod-altdomains.tls.certresolver: "letsencrypt"
+      # Longpolling service
+      traefik.http.routers.myproject-odoo-7-0-prod-longpolling.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-7-0-prod-longpolling.rule:
+        "host(`${DOMAIN_PROD}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.myproject-odoo-7-0-prod-longpolling.service: "myproject-odoo-7-0-prod-longpolling"
+      traefik.http.services.myproject-odoo-7-0-prod-longpolling.loadbalancer.server.port: 8072
+      traefik.http.routers.myproject-odoo-7-0-prod-longpolling.tls: "true"
+      traefik.http.routers.myproject-odoo-7-0-prod-longpolling.tls.certresolver: "letsencrypt"
 
   db:
     extends:

--- a/tests/default_settings/v7.0/test.yaml
+++ b/tests/default_settings/v7.0/test.yaml
@@ -26,6 +26,24 @@ services:
       traefik.frontend.headers.customResponseHeaders: "X-Robots-Tag:noindex, nofollow"
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_TEST};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
+      # Main service
+      ? traefik.http.middlewares.myproject-odoo-7-0-test-main-buffering.buffering.retryExpression
+      : "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.myproject-odoo-7-0-test-main-compress.compress: "true"
+      traefik.http.routers.myproject-odoo-7-0-test-main.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-7-0-test-main.middlewares: "myproject-odoo-7-0-test-main-compress,myproject-odoo-7-0-test-main-buffering"
+      traefik.http.routers.myproject-odoo-7-0-test-main.rule: "host(`${DOMAIN_TEST}`)"
+      traefik.http.routers.myproject-odoo-7-0-test-main.service: "myproject-odoo-7-0-test-main"
+      traefik.http.routers.myproject-odoo-7-0-test-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-7-0-test-main.loadbalancer.server.port: 8069
+      # Longpolling service
+      traefik.http.routers.myproject-odoo-7-0-test-longpolling.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-7-0-test-longpolling.rule:
+        "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.myproject-odoo-7-0-test-longpolling.service: "myproject-odoo-7-0-test-longpolling"
+      traefik.http.routers.myproject-odoo-7-0-test-longpolling.tls: "true"
+      traefik.http.routers.myproject-odoo-7-0-test-longpolling.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-7-0-test-longpolling.loadbalancer.server.port: 8072
     command:
       - odoo
       - --workers=2

--- a/tests/default_settings/v8.0/prod.yaml
+++ b/tests/default_settings/v8.0/prod.yaml
@@ -20,6 +20,34 @@ services:
     labels:
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_PROD};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_PROD}"
+      # Main service
+      ? traefik.http.middlewares.myproject-odoo-8-0-prod-main-buffering.buffering.retryExpression
+      : "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.myproject-odoo-8-0-prod-main-compress.compress: "true"
+      traefik.http.routers.myproject-odoo-8-0-prod-main.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-8-0-prod-main.middlewares: "myproject-odoo-8-0-prod-main-compress,myproject-odoo-8-0-prod-main-buffering"
+      traefik.http.routers.myproject-odoo-8-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
+      traefik.http.routers.myproject-odoo-8-0-prod-main.service: "myproject-odoo-8-0-prod-main"
+      traefik.http.routers.myproject-odoo-8-0-prod-main.tls: "true"
+      traefik.http.routers.myproject-odoo-8-0-prod-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-8-0-prod-main.loadbalancer.server.port: 8069
+      # Redirect alternative domains to main domain
+      traefik.http.middlewares.myproject-odoo-8-0-prod-redirect2main.redirectregex.regex: "^https://([^/]+)/(.*)$$"
+      traefik.http.middlewares.myproject-odoo-8-0-prod-redirect2main.redirectregex.replacement: "https://${DOMAIN_PROD}/$${2}"
+      traefik.http.routers.myproject-odoo-8-0-prod-altdomains.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-8-0-prod-altdomains.middlewares: "myproject-odoo-8-0-prod-redirect2main"
+      traefik.http.routers.myproject-odoo-8-0-prod-altdomains.rule: "host(`${DOMAIN_PROD_ALT}`)"
+      traefik.http.routers.myproject-odoo-8-0-prod-altdomains.service: "myproject-odoo-8-0-prod-main"
+      traefik.http.routers.myproject-odoo-8-0-prod-altdomains.tls: "true"
+      traefik.http.routers.myproject-odoo-8-0-prod-altdomains.tls.certresolver: "letsencrypt"
+      # Longpolling service
+      traefik.http.routers.myproject-odoo-8-0-prod-longpolling.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-8-0-prod-longpolling.rule:
+        "host(`${DOMAIN_PROD}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.myproject-odoo-8-0-prod-longpolling.service: "myproject-odoo-8-0-prod-longpolling"
+      traefik.http.services.myproject-odoo-8-0-prod-longpolling.loadbalancer.server.port: 8072
+      traefik.http.routers.myproject-odoo-8-0-prod-longpolling.tls: "true"
+      traefik.http.routers.myproject-odoo-8-0-prod-longpolling.tls.certresolver: "letsencrypt"
 
   db:
     extends:

--- a/tests/default_settings/v8.0/test.yaml
+++ b/tests/default_settings/v8.0/test.yaml
@@ -26,6 +26,24 @@ services:
       traefik.frontend.headers.customResponseHeaders: "X-Robots-Tag:noindex, nofollow"
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_TEST};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
+      # Main service
+      ? traefik.http.middlewares.myproject-odoo-8-0-test-main-buffering.buffering.retryExpression
+      : "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.myproject-odoo-8-0-test-main-compress.compress: "true"
+      traefik.http.routers.myproject-odoo-8-0-test-main.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-8-0-test-main.middlewares: "myproject-odoo-8-0-test-main-compress,myproject-odoo-8-0-test-main-buffering"
+      traefik.http.routers.myproject-odoo-8-0-test-main.rule: "host(`${DOMAIN_TEST}`)"
+      traefik.http.routers.myproject-odoo-8-0-test-main.service: "myproject-odoo-8-0-test-main"
+      traefik.http.routers.myproject-odoo-8-0-test-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-8-0-test-main.loadbalancer.server.port: 8069
+      # Longpolling service
+      traefik.http.routers.myproject-odoo-8-0-test-longpolling.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-8-0-test-longpolling.rule:
+        "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.myproject-odoo-8-0-test-longpolling.service: "myproject-odoo-8-0-test-longpolling"
+      traefik.http.routers.myproject-odoo-8-0-test-longpolling.tls: "true"
+      traefik.http.routers.myproject-odoo-8-0-test-longpolling.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-8-0-test-longpolling.loadbalancer.server.port: 8072
     command:
       - odoo
       - --workers=2

--- a/tests/default_settings/v9.0/prod.yaml
+++ b/tests/default_settings/v9.0/prod.yaml
@@ -20,6 +20,34 @@ services:
     labels:
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_PROD};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_PROD}"
+      # Main service
+      ? traefik.http.middlewares.myproject-odoo-9-0-prod-main-buffering.buffering.retryExpression
+      : "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.myproject-odoo-9-0-prod-main-compress.compress: "true"
+      traefik.http.routers.myproject-odoo-9-0-prod-main.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-9-0-prod-main.middlewares: "myproject-odoo-9-0-prod-main-compress,myproject-odoo-9-0-prod-main-buffering"
+      traefik.http.routers.myproject-odoo-9-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
+      traefik.http.routers.myproject-odoo-9-0-prod-main.service: "myproject-odoo-9-0-prod-main"
+      traefik.http.routers.myproject-odoo-9-0-prod-main.tls: "true"
+      traefik.http.routers.myproject-odoo-9-0-prod-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-9-0-prod-main.loadbalancer.server.port: 8069
+      # Redirect alternative domains to main domain
+      traefik.http.middlewares.myproject-odoo-9-0-prod-redirect2main.redirectregex.regex: "^https://([^/]+)/(.*)$$"
+      traefik.http.middlewares.myproject-odoo-9-0-prod-redirect2main.redirectregex.replacement: "https://${DOMAIN_PROD}/$${2}"
+      traefik.http.routers.myproject-odoo-9-0-prod-altdomains.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-9-0-prod-altdomains.middlewares: "myproject-odoo-9-0-prod-redirect2main"
+      traefik.http.routers.myproject-odoo-9-0-prod-altdomains.rule: "host(`${DOMAIN_PROD_ALT}`)"
+      traefik.http.routers.myproject-odoo-9-0-prod-altdomains.service: "myproject-odoo-9-0-prod-main"
+      traefik.http.routers.myproject-odoo-9-0-prod-altdomains.tls: "true"
+      traefik.http.routers.myproject-odoo-9-0-prod-altdomains.tls.certresolver: "letsencrypt"
+      # Longpolling service
+      traefik.http.routers.myproject-odoo-9-0-prod-longpolling.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-9-0-prod-longpolling.rule:
+        "host(`${DOMAIN_PROD}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.myproject-odoo-9-0-prod-longpolling.service: "myproject-odoo-9-0-prod-longpolling"
+      traefik.http.services.myproject-odoo-9-0-prod-longpolling.loadbalancer.server.port: 8072
+      traefik.http.routers.myproject-odoo-9-0-prod-longpolling.tls: "true"
+      traefik.http.routers.myproject-odoo-9-0-prod-longpolling.tls.certresolver: "letsencrypt"
 
   db:
     extends:

--- a/tests/default_settings/v9.0/test.yaml
+++ b/tests/default_settings/v9.0/test.yaml
@@ -26,6 +26,24 @@ services:
       traefik.frontend.headers.customResponseHeaders: "X-Robots-Tag:noindex, nofollow"
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_TEST};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
+      # Main service
+      ? traefik.http.middlewares.myproject-odoo-9-0-test-main-buffering.buffering.retryExpression
+      : "IsNetworkError() && Attempts() < 5"
+      traefik.http.middlewares.myproject-odoo-9-0-test-main-compress.compress: "true"
+      traefik.http.routers.myproject-odoo-9-0-test-main.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-9-0-test-main.middlewares: "myproject-odoo-9-0-test-main-compress,myproject-odoo-9-0-test-main-buffering"
+      traefik.http.routers.myproject-odoo-9-0-test-main.rule: "host(`${DOMAIN_TEST}`)"
+      traefik.http.routers.myproject-odoo-9-0-test-main.service: "myproject-odoo-9-0-test-main"
+      traefik.http.routers.myproject-odoo-9-0-test-main.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-9-0-test-main.loadbalancer.server.port: 8069
+      # Longpolling service
+      traefik.http.routers.myproject-odoo-9-0-test-longpolling.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-9-0-test-longpolling.rule:
+        "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
+      traefik.http.routers.myproject-odoo-9-0-test-longpolling.service: "myproject-odoo-9-0-test-longpolling"
+      traefik.http.routers.myproject-odoo-9-0-test-longpolling.tls: "true"
+      traefik.http.routers.myproject-odoo-9-0-test-longpolling.tls.certresolver: "letsencrypt"
+      traefik.http.services.myproject-odoo-9-0-test-longpolling.loadbalancer.server.port: 8072
     command:
       - odoo
       - --workers=2

--- a/tests/test_default_settings.py
+++ b/tests/test_default_settings.py
@@ -27,6 +27,10 @@ def test_default_settings(tmp_path: Path, odoo_version: float):
             force=True,
             data={"odoo_version": odoo_version},
         )
+    with local.cwd(dst):
+        git("add", ".")
+        pre_commit("run", "-a", retcode=None)
+        git("commit", "-am", "Hello World")
     # The result matches what we expect
     diff(
         "--context=3",
@@ -35,11 +39,6 @@ def test_default_settings(tmp_path: Path, odoo_version: float):
         local.cwd / "tests" / "default_settings" / f"v{odoo_version:.1f}",
         dst,
     )
-    # The result is a git repo that does not violate pre-commit
-    with local.cwd(dst):
-        git("add", ".")
-        git("commit", "-m", "Hello World")
-        pre_commit("run", "-a")
 
 
 @pytest.mark.parametrize("odoo_version", (10.0, 13.0))


### PR DESCRIPTION


This will finally finish Tecnativa/doodba-scaffolding#67 by adding suport for Traefik 2.x and including a workaround for containous/traefik#5134 that should allow us to have 1 test and 1 prod instances together in the same machine.

Traefik 2 support is still experimental so use at your own risk. No docs yet, to emphasize that.

@Tecnativa TT21776

