### PR TITLE
Use custom pylint templates

### DIFF
--- a/.pylintrc-mandatory.jinja
+++ b/.pylintrc-mandatory.jinja
@@ -1,1 +1,61 @@
-{%- include "vendor/maintainer-quality-tools/sample_files/pre-commit-13.0/.pylintrc-mandatory" -%}
+[MASTER]
+load-plugins=pylint_odoo
+score=n
+
+[ODOOLINT]
+readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
+manifest_required_keys=license
+manifest_deprecated_keys=active
+valid_odoo_versions=13.0
+
+[MESSAGES CONTROL]
+disable=all
+
+enable=anomalous-backslash-in-string,
+    api-one-deprecated,
+    api-one-multi-together,
+    assignment-from-none,
+    attribute-deprecated,
+    class-camelcase,
+    dangerous-default-value,
+    dangerous-view-replace-wo-priority,
+    duplicate-id-csv,
+    duplicate-key,
+    duplicate-xml-fields,
+    duplicate-xml-record-id,
+    eval-referenced,
+    eval-used,
+    incoherent-interpreter-exec-perm,
+    manifest-author-string,
+    manifest-deprecated-key,
+    manifest-required-key,
+    manifest-version-format,
+    method-compute,
+    method-inverse,
+    method-required-super,
+    method-search,
+    missing-import-error,
+    missing-manifest-dependency,
+    openerp-exception-warning,
+    pointless-statement,
+    pointless-string-statement,
+    print-used,
+    redundant-keyword-arg,
+    redundant-modulename-xml,
+    reimported,
+    relative-import,
+    return-in-init,
+    rst-syntax-error,
+    sql-injection,
+    too-few-format-args,
+    translation-field,
+    translation-required,
+    unreachable,
+    use-vim-comment,
+    wrong-tabs-instead-of-spaces,
+    xml-syntax-error
+
+[REPORTS]
+msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
+output-format=colorized
+reports=no

--- a/.pylintrc.jinja
+++ b/.pylintrc.jinja
@@ -1,1 +1,89 @@
-{%- include "vendor/maintainer-quality-tools/sample_files/pre-commit-13.0/.pylintrc" -%}
+[MASTER]
+load-plugins=pylint_odoo
+score=n
+
+[ODOOLINT]
+readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
+manifest_required_authors={{ project_author }}
+manifest_required_keys=license
+manifest_deprecated_keys=description,active
+license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
+valid_odoo_versions=13.0
+
+[MESSAGES CONTROL]
+disable=all
+
+# This .pylintrc contains optional AND mandatory checks and is meant to be
+# loaded in an IDE to have it check everything, in the hope this will make
+# optional checks more visible to contributors who otherwise never look at a
+# green travis to see optional checks that failed.
+# .pylintrc-mandatory containing only mandatory checks is used the pre-commit
+# config as a blocking check.
+
+enable=anomalous-backslash-in-string,
+    api-one-deprecated,
+    api-one-multi-together,
+    assignment-from-none,
+    attribute-deprecated,
+    class-camelcase,
+    dangerous-default-value,
+    dangerous-view-replace-wo-priority,
+    duplicate-id-csv,
+    duplicate-key,
+    duplicate-xml-fields,
+    duplicate-xml-record-id,
+    eval-referenced,
+    eval-used,
+    incoherent-interpreter-exec-perm,
+    license-allowed,
+    manifest-author-string,
+    manifest-deprecated-key,
+    {%- if project_author %}
+    manifest-required-author,
+    {%- endif %}
+    manifest-required-key,
+    manifest-version-format,
+    method-compute,
+    method-inverse,
+    method-required-super,
+    method-search,
+    missing-import-error,
+    missing-manifest-dependency,
+    openerp-exception-warning,
+    pointless-statement,
+    pointless-string-statement,
+    print-used,
+    redundant-keyword-arg,
+    redundant-modulename-xml,
+    reimported,
+    relative-import,
+    return-in-init,
+    rst-syntax-error,
+    sql-injection,
+    too-few-format-args,
+    translation-field,
+    translation-required,
+    unreachable,
+    use-vim-comment,
+    wrong-tabs-instead-of-spaces,
+    xml-syntax-error,
+    # messages that do not cause the lint step to fail
+    consider-merging-classes-inherited,
+    create-user-wo-reset-password,
+    dangerous-filter-wo-user,
+    deprecated-module,
+    file-not-used,
+    invalid-commit,
+    missing-newline-extrafiles,
+    missing-readme,
+    no-utf8-coding-comment,
+    odoo-addons-relative-import,
+    old-api7-method-defined,
+    redefined-builtin,
+    too-complex,
+    unnecessary-utf8-coding-comment
+
+[REPORTS]
+msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
+output-format=colorized
+reports=no

--- a/copier.yml
+++ b/copier.yml
@@ -47,6 +47,14 @@ _migrations:
         - from-doodba-scaffolding-to-copier
 
 # Questions for the user
+project_author:
+  type: str
+  help: >-
+    Tell me who you are.
+
+    If private modules do not include this author, pylint will warn you.
+  default: Tecnativa, S.L.
+
 project_name:
   type: str
   help: >-

--- a/tests/default_settings/v10.0/.copier-answers.yml
+++ b/tests/default_settings/v10.0/.copier-answers.yml
@@ -21,6 +21,7 @@ odoo_version: 10.0
 postgres_dbname: prod
 postgres_username: odoo
 postgres_version: 12
+project_author: Tecnativa, S.L.
 project_license: BSL-1.0
 project_name: myproject-odoo
 smtp_canonical_default: null

--- a/tests/default_settings/v10.0/.pylintrc
+++ b/tests/default_settings/v10.0/.pylintrc
@@ -4,10 +4,10 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Odoo Community Association (OCA)
+manifest_required_authors=Tecnativa, S.L.
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]

--- a/tests/default_settings/v10.0/.pylintrc-mandatory
+++ b/tests/default_settings/v10.0/.pylintrc-mandatory
@@ -4,10 +4,8 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Odoo Community Association (OCA)
 manifest_required_keys=license
-manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+manifest_deprecated_keys=active
 valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]
@@ -28,10 +26,8 @@ enable=anomalous-backslash-in-string,
     eval-referenced,
     eval-used,
     incoherent-interpreter-exec-perm,
-    license-allowed,
     manifest-author-string,
     manifest-deprecated-key,
-    manifest-required-author,
     manifest-required-key,
     manifest-version-format,
     method-compute,

--- a/tests/default_settings/v11.0/.copier-answers.yml
+++ b/tests/default_settings/v11.0/.copier-answers.yml
@@ -21,6 +21,7 @@ odoo_version: 11.0
 postgres_dbname: prod
 postgres_username: odoo
 postgres_version: 12
+project_author: Tecnativa, S.L.
 project_license: BSL-1.0
 project_name: myproject-odoo
 smtp_canonical_default: null

--- a/tests/default_settings/v11.0/.pylintrc
+++ b/tests/default_settings/v11.0/.pylintrc
@@ -4,10 +4,10 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Odoo Community Association (OCA)
+manifest_required_authors=Tecnativa, S.L.
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]

--- a/tests/default_settings/v11.0/.pylintrc-mandatory
+++ b/tests/default_settings/v11.0/.pylintrc-mandatory
@@ -4,10 +4,8 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Odoo Community Association (OCA)
 manifest_required_keys=license
-manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+manifest_deprecated_keys=active
 valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]
@@ -28,10 +26,8 @@ enable=anomalous-backslash-in-string,
     eval-referenced,
     eval-used,
     incoherent-interpreter-exec-perm,
-    license-allowed,
     manifest-author-string,
     manifest-deprecated-key,
-    manifest-required-author,
     manifest-required-key,
     manifest-version-format,
     method-compute,

--- a/tests/default_settings/v12.0/.copier-answers.yml
+++ b/tests/default_settings/v12.0/.copier-answers.yml
@@ -21,6 +21,7 @@ odoo_version: 12.0
 postgres_dbname: prod
 postgres_username: odoo
 postgres_version: 12
+project_author: Tecnativa, S.L.
 project_license: BSL-1.0
 project_name: myproject-odoo
 smtp_canonical_default: null

--- a/tests/default_settings/v12.0/.pylintrc
+++ b/tests/default_settings/v12.0/.pylintrc
@@ -4,10 +4,10 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Odoo Community Association (OCA)
+manifest_required_authors=Tecnativa, S.L.
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]

--- a/tests/default_settings/v12.0/.pylintrc-mandatory
+++ b/tests/default_settings/v12.0/.pylintrc-mandatory
@@ -4,10 +4,8 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Odoo Community Association (OCA)
 manifest_required_keys=license
-manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+manifest_deprecated_keys=active
 valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]
@@ -28,10 +26,8 @@ enable=anomalous-backslash-in-string,
     eval-referenced,
     eval-used,
     incoherent-interpreter-exec-perm,
-    license-allowed,
     manifest-author-string,
     manifest-deprecated-key,
-    manifest-required-author,
     manifest-required-key,
     manifest-version-format,
     method-compute,

--- a/tests/default_settings/v13.0/.copier-answers.yml
+++ b/tests/default_settings/v13.0/.copier-answers.yml
@@ -21,6 +21,7 @@ odoo_version: 13.0
 postgres_dbname: prod
 postgres_username: odoo
 postgres_version: 12
+project_author: Tecnativa, S.L.
 project_license: BSL-1.0
 project_name: myproject-odoo
 smtp_canonical_default: null

--- a/tests/default_settings/v13.0/.pylintrc
+++ b/tests/default_settings/v13.0/.pylintrc
@@ -4,10 +4,10 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Odoo Community Association (OCA)
+manifest_required_authors=Tecnativa, S.L.
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]

--- a/tests/default_settings/v13.0/.pylintrc-mandatory
+++ b/tests/default_settings/v13.0/.pylintrc-mandatory
@@ -4,10 +4,8 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Odoo Community Association (OCA)
 manifest_required_keys=license
-manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+manifest_deprecated_keys=active
 valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]
@@ -28,10 +26,8 @@ enable=anomalous-backslash-in-string,
     eval-referenced,
     eval-used,
     incoherent-interpreter-exec-perm,
-    license-allowed,
     manifest-author-string,
     manifest-deprecated-key,
-    manifest-required-author,
     manifest-required-key,
     manifest-version-format,
     method-compute,

--- a/tests/default_settings/v7.0/.copier-answers.yml
+++ b/tests/default_settings/v7.0/.copier-answers.yml
@@ -21,6 +21,7 @@ odoo_version: 7.0
 postgres_dbname: prod
 postgres_username: odoo
 postgres_version: 12
+project_author: Tecnativa, S.L.
 project_license: BSL-1.0
 project_name: myproject-odoo
 smtp_canonical_default: null

--- a/tests/default_settings/v7.0/.pylintrc
+++ b/tests/default_settings/v7.0/.pylintrc
@@ -4,10 +4,10 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Odoo Community Association (OCA)
+manifest_required_authors=Tecnativa, S.L.
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]

--- a/tests/default_settings/v7.0/.pylintrc-mandatory
+++ b/tests/default_settings/v7.0/.pylintrc-mandatory
@@ -4,10 +4,8 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Odoo Community Association (OCA)
 manifest_required_keys=license
-manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+manifest_deprecated_keys=active
 valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]
@@ -28,10 +26,8 @@ enable=anomalous-backslash-in-string,
     eval-referenced,
     eval-used,
     incoherent-interpreter-exec-perm,
-    license-allowed,
     manifest-author-string,
     manifest-deprecated-key,
-    manifest-required-author,
     manifest-required-key,
     manifest-version-format,
     method-compute,

--- a/tests/default_settings/v8.0/.copier-answers.yml
+++ b/tests/default_settings/v8.0/.copier-answers.yml
@@ -21,6 +21,7 @@ odoo_version: 8.0
 postgres_dbname: prod
 postgres_username: odoo
 postgres_version: 12
+project_author: Tecnativa, S.L.
 project_license: BSL-1.0
 project_name: myproject-odoo
 smtp_canonical_default: null

--- a/tests/default_settings/v8.0/.pylintrc
+++ b/tests/default_settings/v8.0/.pylintrc
@@ -4,10 +4,10 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Odoo Community Association (OCA)
+manifest_required_authors=Tecnativa, S.L.
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]

--- a/tests/default_settings/v8.0/.pylintrc-mandatory
+++ b/tests/default_settings/v8.0/.pylintrc-mandatory
@@ -4,10 +4,8 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Odoo Community Association (OCA)
 manifest_required_keys=license
-manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+manifest_deprecated_keys=active
 valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]
@@ -28,10 +26,8 @@ enable=anomalous-backslash-in-string,
     eval-referenced,
     eval-used,
     incoherent-interpreter-exec-perm,
-    license-allowed,
     manifest-author-string,
     manifest-deprecated-key,
-    manifest-required-author,
     manifest-required-key,
     manifest-version-format,
     method-compute,

--- a/tests/default_settings/v9.0/.copier-answers.yml
+++ b/tests/default_settings/v9.0/.copier-answers.yml
@@ -21,6 +21,7 @@ odoo_version: 9.0
 postgres_dbname: prod
 postgres_username: odoo
 postgres_version: 12
+project_author: Tecnativa, S.L.
 project_license: BSL-1.0
 project_name: myproject-odoo
 smtp_canonical_default: null

--- a/tests/default_settings/v9.0/.pylintrc
+++ b/tests/default_settings/v9.0/.pylintrc
@@ -4,10 +4,10 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Odoo Community Association (OCA)
+manifest_required_authors=Tecnativa, S.L.
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]

--- a/tests/default_settings/v9.0/.pylintrc-mandatory
+++ b/tests/default_settings/v9.0/.pylintrc-mandatory
@@ -4,10 +4,8 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Odoo Community Association (OCA)
 manifest_required_keys=license
-manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+manifest_deprecated_keys=active
 valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]
@@ -28,10 +26,8 @@ enable=anomalous-backslash-in-string,
     eval-referenced,
     eval-used,
     incoherent-interpreter-exec-perm,
-    license-allowed,
     manifest-author-string,
     manifest-deprecated-key,
-    manifest-required-author,
     manifest-required-key,
     manifest-version-format,
     method-compute,

--- a/tests/good_diffs/.pylintrc-mandatory.diff
+++ b/tests/good_diffs/.pylintrc-mandatory.diff
@@ -1,0 +1,11 @@
+6a7
+> manifest_required_authors=Odoo Community Association (OCA)
+8c9,10
+< manifest_deprecated_keys=active
+---
+> manifest_deprecated_keys=description,active
+> license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+28a31
+>     license-allowed,
+30a34
+>     manifest-required-author,

--- a/tests/good_diffs/.pylintrc.diff
+++ b/tests/good_diffs/.pylintrc.diff
@@ -1,0 +1,8 @@
+7c7
+< manifest_required_authors=Tecnativa, S.L.
+---
+> manifest_required_authors=Odoo Community Association (OCA)
+10c10
+< license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
+---
+> license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3


### PR DESCRIPTION
You could have in your private modules you bought through the apps store. These modules could have `description` keys, and you could be no author there. These modules could have any license you want, or none since they belong to your project, which already has a license.

So, these things are now just warnings.

Also, not having OCA as author is almost *never* an error here, so that's changed for your own author, which is asked when copying.

@Tecnativa TT20357