### PR TITLE
Remove newlines in Traefik labels

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -103,7 +103,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2019.11.28"
+version = "2020.4.5.1"
 
 [[package]]
 category = "dev"
@@ -154,7 +154,7 @@ description = "A library for rendering project templates."
 name = "copier"
 optional = false
 python-versions = ">=3.6,<4.0"
-version = "3.0.2"
+version = "3.0.6"
 
 [package.dependencies]
 colorama = ">=0.4.0,<1.0.0"
@@ -173,8 +173,8 @@ category = "dev"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 name = "cryptography"
 optional = false
-python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
-version = "2.8"
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+version = "2.9"
 
 [package.dependencies]
 cffi = ">=1.8,<1.11.3 || >1.11.3"
@@ -235,7 +235,7 @@ description = "Multi-container orchestration for Docker"
 name = "docker-compose"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.25.4"
+version = "1.25.5"
 
 [package.dependencies]
 PyYAML = ">=3.10,<6"
@@ -325,7 +325,7 @@ description = "File identification library for Python"
 name = "identify"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "1.4.13"
+version = "1.4.14"
 
 [package.extras]
 license = ["editdistance"]
@@ -345,7 +345,7 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.5.0"
+version = "1.6.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -646,7 +646,7 @@ description = "Python parsing module"
 name = "pyparsing"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.6"
+version = "2.4.7"
 
 [[package]]
 category = "dev"
@@ -763,7 +763,7 @@ description = "Alternative regular expression module, to replace re."
 name = "regex"
 optional = false
 python-versions = "*"
-version = "2020.2.20"
+version = "2020.4.4"
 
 [[package]]
 category = "dev"
@@ -834,7 +834,7 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "20.0.13"
+version = "20.0.17"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
@@ -852,7 +852,7 @@ version = ">=1.0,<2"
 
 [package.extras]
 docs = ["sphinx (>=2.0.0,<3)", "sphinx-argparse (>=0.2.5,<1)", "sphinx-rtd-theme (>=0.4.3,<1)", "towncrier (>=19.9.0rc1)", "proselint (>=0.10.2,<1)"]
-testing = ["pytest (>=4.0.0,<6)", "coverage (>=4.5.1,<6)", "pytest-mock (>=2.0.0,<3)", "pytest-env (>=0.6.2,<1)", "pytest-timeout (>=1.3.4,<2)", "packaging (>=20.0)", "xonsh (>=0.9.13,<1)"]
+testing = ["pytest (>=4.0.0,<6)", "coverage (>=4.5.1,<6)", "pytest-mock (>=2.0.0,<3)", "pytest-env (>=0.6.2,<1)", "pytest-timeout (>=1.3.4,<2)", "packaging (>=20.0)", "xonsh (>=0.9.16,<1)"]
 
 [[package]]
 category = "main"
@@ -895,7 +895,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "4dbe7f82e6a09b96f19cc6dff2c179d4f682de9932e17de941ba53b8cd3b791c"
+content-hash = "2f334cc6b8cfc27942a32ed8c329f92f82ced92e2a6f5da53ae6dbfc744173f3"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -948,8 +948,8 @@ cached-property = [
     {file = "cached_property-1.5.1-py2.py3-none-any.whl", hash = "sha256:3a026f1a54135677e7da5ce819b0c690f156f37976f3e30c5430740725203d7f"},
 ]
 certifi = [
-    {file = "certifi-2019.11.28-py2.py3-none-any.whl", hash = "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3"},
-    {file = "certifi-2019.11.28.tar.gz", hash = "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"},
+    {file = "certifi-2020.4.5.1-py2.py3-none-any.whl", hash = "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304"},
+    {file = "certifi-2020.4.5.1.tar.gz", hash = "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"},
 ]
 cffi = [
     {file = "cffi-1.14.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1cae98a7054b5c9391eb3249b86e0e99ab1e02bb0cc0575da191aedadbdf4384"},
@@ -998,31 +998,29 @@ colorama = [
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
 copier = [
-    {file = "copier-3.0.2-py3-none-any.whl", hash = "sha256:c0ecf70cbe7df5973996b2fb52980005ec7282ccc05dbdd66293d9c900f075f5"},
-    {file = "copier-3.0.2.tar.gz", hash = "sha256:61ab23c1e8e31d6ee9b4ad39cfe0e42d4ebdabdd19eec3b719b70af897d3a3a5"},
+    {file = "copier-3.0.6-py3-none-any.whl", hash = "sha256:e51926edf9885cfdf5b3176c02e5975db8bc5347548245a1fb0798547a391a62"},
+    {file = "copier-3.0.6.tar.gz", hash = "sha256:848b639ae5bef036e50a051cd2f5db26ee1c8205055b805fbe6e098d03cd4be2"},
 ]
 cryptography = [
-    {file = "cryptography-2.8-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:fb81c17e0ebe3358486cd8cc3ad78adbae58af12fc2bf2bc0bb84e8090fa5ce8"},
-    {file = "cryptography-2.8-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:44ff04138935882fef7c686878e1c8fd80a723161ad6a98da31e14b7553170c2"},
-    {file = "cryptography-2.8-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:369d2346db5934345787451504853ad9d342d7f721ae82d098083e1f49a582ad"},
-    {file = "cryptography-2.8-cp27-cp27m-win32.whl", hash = "sha256:df6b4dca2e11865e6cfbfb708e800efb18370f5a46fd601d3755bc7f85b3a8a2"},
-    {file = "cryptography-2.8-cp27-cp27m-win_amd64.whl", hash = "sha256:7f09806ed4fbea8f51585231ba742b58cbcfbfe823ea197d8c89a5e433c7e912"},
-    {file = "cryptography-2.8-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:58363dbd966afb4f89b3b11dfb8ff200058fbc3b947507675c19ceb46104b48d"},
-    {file = "cryptography-2.8-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:6ec280fb24d27e3d97aa731e16207d58bd8ae94ef6eab97249a2afe4ba643d42"},
-    {file = "cryptography-2.8-cp34-abi3-macosx_10_6_intel.whl", hash = "sha256:b43f53f29816ba1db8525f006fa6f49292e9b029554b3eb56a189a70f2a40879"},
-    {file = "cryptography-2.8-cp34-abi3-manylinux1_x86_64.whl", hash = "sha256:7270a6c29199adc1297776937a05b59720e8a782531f1f122f2eb8467f9aab4d"},
-    {file = "cryptography-2.8-cp34-abi3-manylinux2010_x86_64.whl", hash = "sha256:de96157ec73458a7f14e3d26f17f8128c959084931e8997b9e655a39c8fde9f9"},
-    {file = "cryptography-2.8-cp34-cp34m-win32.whl", hash = "sha256:02079a6addc7b5140ba0825f542c0869ff4df9a69c360e339ecead5baefa843c"},
-    {file = "cryptography-2.8-cp34-cp34m-win_amd64.whl", hash = "sha256:b0de590a8b0979649ebeef8bb9f54394d3a41f66c5584fff4220901739b6b2f0"},
-    {file = "cryptography-2.8-cp35-cp35m-win32.whl", hash = "sha256:ecadccc7ba52193963c0475ac9f6fa28ac01e01349a2ca48509667ef41ffd2cf"},
-    {file = "cryptography-2.8-cp35-cp35m-win_amd64.whl", hash = "sha256:90df0cc93e1f8d2fba8365fb59a858f51a11a394d64dbf3ef844f783844cc793"},
-    {file = "cryptography-2.8-cp36-cp36m-win32.whl", hash = "sha256:1df22371fbf2004c6f64e927668734070a8953362cd8370ddd336774d6743595"},
-    {file = "cryptography-2.8-cp36-cp36m-win_amd64.whl", hash = "sha256:a518c153a2b5ed6b8cc03f7ae79d5ffad7315ad4569b2d5333a13c38d64bd8d7"},
-    {file = "cryptography-2.8-cp37-cp37m-win32.whl", hash = "sha256:4b1030728872c59687badcca1e225a9103440e467c17d6d1730ab3d2d64bfeff"},
-    {file = "cryptography-2.8-cp37-cp37m-win_amd64.whl", hash = "sha256:d31402aad60ed889c7e57934a03477b572a03af7794fa8fb1780f21ea8f6551f"},
-    {file = "cryptography-2.8-cp38-cp38-win32.whl", hash = "sha256:73fd30c57fa2d0a1d7a49c561c40c2f79c7d6c374cc7750e9ac7c99176f6428e"},
-    {file = "cryptography-2.8-cp38-cp38-win_amd64.whl", hash = "sha256:971221ed40f058f5662a604bd1ae6e4521d84e6cad0b7b170564cc34169c8f13"},
-    {file = "cryptography-2.8.tar.gz", hash = "sha256:3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651"},
+    {file = "cryptography-2.9-cp27-cp27m-macosx_10_9_intel.whl", hash = "sha256:ef9a55013676907df6c9d7dd943eb1770d014f68beaa7e73250fb43c759f4585"},
+    {file = "cryptography-2.9-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:2a2ad24d43398d89f92209289f15265107928f22a8d10385f70def7a698d6a02"},
+    {file = "cryptography-2.9-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:95e1296e0157361fe2f5f0ed307fd31f94b0ca13372e3673fa95095a627636a1"},
+    {file = "cryptography-2.9-cp27-cp27m-win32.whl", hash = "sha256:192ca04a36852a994ef21df13cca4d822adbbdc9d5009c0f96f1d2929e375d4f"},
+    {file = "cryptography-2.9-cp27-cp27m-win_amd64.whl", hash = "sha256:ed1d0760c7e46436ec90834d6f10477ff09475c692ed1695329d324b2c5cd547"},
+    {file = "cryptography-2.9-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:19ae795137682a9778892fb4390c07811828b173741bce91e30f899424b3934d"},
+    {file = "cryptography-2.9-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:d1bf5a1a0d60c7f9a78e448adcb99aa101f3f9588b16708044638881be15d6bc"},
+    {file = "cryptography-2.9-cp35-abi3-macosx_10_9_intel.whl", hash = "sha256:1b9b535d6b55936a79dbe4990b64bb16048f48747c76c29713fea8c50eca2acf"},
+    {file = "cryptography-2.9-cp35-abi3-manylinux1_x86_64.whl", hash = "sha256:7a279f33a081d436e90e91d1a7c338553c04e464de1c9302311a5e7e4b746088"},
+    {file = "cryptography-2.9-cp35-abi3-manylinux2010_x86_64.whl", hash = "sha256:49870684da168b90110bbaf86140d4681032c5e6a2461adc7afdd93be5634216"},
+    {file = "cryptography-2.9-cp35-cp35m-win32.whl", hash = "sha256:6b91cab3841b4c7cb70e4db1697c69f036c8bc0a253edc0baa6783154f1301e4"},
+    {file = "cryptography-2.9-cp35-cp35m-win_amd64.whl", hash = "sha256:587f98ce27ac4547177a0c6fe0986b8736058daffe9160dcf5f1bd411b7fbaa1"},
+    {file = "cryptography-2.9-cp36-cp36m-win32.whl", hash = "sha256:cc20316e3f5a6b582fc3b029d8dc03aabeb645acfcb7fc1d9848841a33265748"},
+    {file = "cryptography-2.9-cp36-cp36m-win_amd64.whl", hash = "sha256:3be7a5722d5bfe69894d3f7bbed15547b17619f3a88a318aab2e37f457524164"},
+    {file = "cryptography-2.9-cp37-cp37m-win32.whl", hash = "sha256:7598974f6879a338c785c513e7c5a4329fbc58b9f6b9a6305035fca5b1076552"},
+    {file = "cryptography-2.9-cp37-cp37m-win_amd64.whl", hash = "sha256:5aca6f00b2f42546b9bdf11a69f248d1881212ce5b9e2618b04935b87f6f82a1"},
+    {file = "cryptography-2.9-cp38-cp38-win32.whl", hash = "sha256:9fc9da390e98cb6975eadf251b6e5fa088820141061bf041cd5c72deba1dc526"},
+    {file = "cryptography-2.9-cp38-cp38-win_amd64.whl", hash = "sha256:6b744039b55988519cc183149cceb573189b3e46e16ccf6f8c46798bb767c9dc"},
+    {file = "cryptography-2.9.tar.gz", hash = "sha256:0cacd3ef5c604b8e5f59bf2582c076c98a37fe206b31430d0cd08138aff0986e"},
 ]
 dataclasses = [
     {file = "dataclasses-0.6-py3-none-any.whl", hash = "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f"},
@@ -1036,8 +1034,8 @@ docker = [
     {file = "docker-4.2.0.tar.gz", hash = "sha256:ddae66620ab5f4bce769f64bcd7934f880c8abe6aa50986298db56735d0f722e"},
 ]
 docker-compose = [
-    {file = "docker-compose-1.25.4.tar.gz", hash = "sha256:fabae2bee4abfa7bdd09125b6bbdcdda81f946c7b16e3ccc6bb2d821ef6488f3"},
-    {file = "docker_compose-1.25.4-py2.py3-none-any.whl", hash = "sha256:1de906a211c7f4a647f907b1382cd07bbceaf60f4af41c1eebbac74a82210fa5"},
+    {file = "docker-compose-1.25.5.tar.gz", hash = "sha256:7a2eb6d8173fdf408e505e6f7d497ac0b777388719542be9e49a0efd477a50c6"},
+    {file = "docker_compose-1.25.5-py2.py3-none-any.whl", hash = "sha256:9d33520ae976f524968a64226516ec631dce09fba0974ce5366ad403e203eb5d"},
 ]
 dockerpty = [
     {file = "dockerpty-0.4.1.tar.gz", hash = "sha256:69a9d69d573a0daa31bcd1c0774eeed5c15c295fe719c61aca550ed1393156ce"},
@@ -1062,16 +1060,16 @@ flake8 = [
     {file = "flake8-3.7.9.tar.gz", hash = "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb"},
 ]
 identify = [
-    {file = "identify-1.4.13-py2.py3-none-any.whl", hash = "sha256:a7577a1f55cee1d21953a5cf11a3c839ab87f5ef909a4cba6cf52ed72b4c6059"},
-    {file = "identify-1.4.13.tar.gz", hash = "sha256:ab246293e6585a1c6361a505b68d5b501a0409310932b7de2c2ead667b564d89"},
+    {file = "identify-1.4.14-py2.py3-none-any.whl", hash = "sha256:2bb8760d97d8df4408f4e805883dad26a2d076f04be92a10a3e43f09c6060742"},
+    {file = "identify-1.4.14.tar.gz", hash = "sha256:faffea0fd8ec86bb146ac538ac350ed0c73908326426d387eded0bcc9d077522"},
 ]
 idna = [
     {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
     {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.5.0-py2.py3-none-any.whl", hash = "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"},
-    {file = "importlib_metadata-1.5.0.tar.gz", hash = "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302"},
+    {file = "importlib_metadata-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f"},
+    {file = "importlib_metadata-1.6.0.tar.gz", hash = "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"},
 ]
 importlib-resources = [
     {file = "importlib_resources-1.4.0-py2.py3-none-any.whl", hash = "sha256:dd98ceeef3f5ad2ef4cc287b8586da4ebad15877f351e9688987ad663a0a29b8"},
@@ -1247,8 +1245,8 @@ pynacl = [
     {file = "PyNaCl-1.3.0.tar.gz", hash = "sha256:0c6100edd16fefd1557da078c7a31e7b7d7a52ce39fdca2bec29d4f7b6e7600c"},
 ]
 pyparsing = [
-    {file = "pyparsing-2.4.6-py2.py3-none-any.whl", hash = "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"},
-    {file = "pyparsing-2.4.6.tar.gz", hash = "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f"},
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pypiwin32 = [
     {file = "pypiwin32-223-py3-none-any.whl", hash = "sha256:67adf399debc1d5d14dffc1ab5acacb800da569754fafdc576b2a039485aa775"},
@@ -1301,27 +1299,27 @@ pyyaml-include = [
     {file = "pyyaml_include-1.2-py2.py3-none-any.whl", hash = "sha256:2d4e3843110cf515aaf1568b217b05061f8e9f57cd3b35e8e654c838717796cb"},
 ]
 regex = [
-    {file = "regex-2020.2.20-cp27-cp27m-win32.whl", hash = "sha256:99272d6b6a68c7ae4391908fc15f6b8c9a6c345a46b632d7fdb7ef6c883a2bbb"},
-    {file = "regex-2020.2.20-cp27-cp27m-win_amd64.whl", hash = "sha256:974535648f31c2b712a6b2595969f8ab370834080e00ab24e5dbb9d19b8bfb74"},
-    {file = "regex-2020.2.20-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5de40649d4f88a15c9489ed37f88f053c15400257eeb18425ac7ed0a4e119400"},
-    {file = "regex-2020.2.20-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:82469a0c1330a4beb3d42568f82dffa32226ced006e0b063719468dcd40ffdf0"},
-    {file = "regex-2020.2.20-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d58a4fa7910102500722defbde6e2816b0372a4fcc85c7e239323767c74f5cbc"},
-    {file = "regex-2020.2.20-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f1ac2dc65105a53c1c2d72b1d3e98c2464a133b4067a51a3d2477b28449709a0"},
-    {file = "regex-2020.2.20-cp36-cp36m-win32.whl", hash = "sha256:8c2b7fa4d72781577ac45ab658da44c7518e6d96e2a50d04ecb0fd8f28b21d69"},
-    {file = "regex-2020.2.20-cp36-cp36m-win_amd64.whl", hash = "sha256:269f0c5ff23639316b29f31df199f401e4cb87529eafff0c76828071635d417b"},
-    {file = "regex-2020.2.20-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:bed7986547ce54d230fd8721aba6fd19459cdc6d315497b98686d0416efaff4e"},
-    {file = "regex-2020.2.20-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:046e83a8b160aff37e7034139a336b660b01dbfe58706f9d73f5cdc6b3460242"},
-    {file = "regex-2020.2.20-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b33ebcd0222c1d77e61dbcd04a9fd139359bded86803063d3d2d197b796c63ce"},
-    {file = "regex-2020.2.20-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:bba52d72e16a554d1894a0cc74041da50eea99a8483e591a9edf1025a66843ab"},
-    {file = "regex-2020.2.20-cp37-cp37m-win32.whl", hash = "sha256:01b2d70cbaed11f72e57c1cfbaca71b02e3b98f739ce33f5f26f71859ad90431"},
-    {file = "regex-2020.2.20-cp37-cp37m-win_amd64.whl", hash = "sha256:113309e819634f499d0006f6200700c8209a2a8bf6bd1bdc863a4d9d6776a5d1"},
-    {file = "regex-2020.2.20-cp38-cp38-manylinux1_i686.whl", hash = "sha256:25f4ce26b68425b80a233ce7b6218743c71cf7297dbe02feab1d711a2bf90045"},
-    {file = "regex-2020.2.20-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:9b64a4cc825ec4df262050c17e18f60252cdd94742b4ba1286bcfe481f1c0f26"},
-    {file = "regex-2020.2.20-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:9ff16d994309b26a1cdf666a6309c1ef51ad4f72f99d3392bcd7b7139577a1f2"},
-    {file = "regex-2020.2.20-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:c7f58a0e0e13fb44623b65b01052dae8e820ed9b8b654bb6296bc9c41f571b70"},
-    {file = "regex-2020.2.20-cp38-cp38-win32.whl", hash = "sha256:200539b5124bc4721247a823a47d116a7a23e62cc6695744e3eb5454a8888e6d"},
-    {file = "regex-2020.2.20-cp38-cp38-win_amd64.whl", hash = "sha256:7f78f963e62a61e294adb6ff5db901b629ef78cb2a1cfce3cf4eeba80c1c67aa"},
-    {file = "regex-2020.2.20.tar.gz", hash = "sha256:9e9624440d754733eddbcd4614378c18713d2d9d0dc647cf9c72f64e39671be5"},
+    {file = "regex-2020.4.4-cp27-cp27m-win32.whl", hash = "sha256:90742c6ff121a9c5b261b9b215cb476eea97df98ea82037ec8ac95d1be7a034f"},
+    {file = "regex-2020.4.4-cp27-cp27m-win_amd64.whl", hash = "sha256:24f4f4062eb16c5bbfff6a22312e8eab92c2c99c51a02e39b4eae54ce8255cd1"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:08119f707f0ebf2da60d2f24c2f39ca616277bb67ef6c92b72cbf90cbe3a556b"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:c9423a150d3a4fc0f3f2aae897a59919acd293f4cb397429b120a5fcd96ea3db"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:c087bff162158536387c53647411db09b6ee3f9603c334c90943e97b1052a156"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:1cbe0fa0b7f673400eb29e9ef41d4f53638f65f9a2143854de6b1ce2899185c3"},
+    {file = "regex-2020.4.4-cp36-cp36m-win32.whl", hash = "sha256:0ce9537396d8f556bcfc317c65b6a0705320701e5ce511f05fc04421ba05b8a8"},
+    {file = "regex-2020.4.4-cp36-cp36m-win_amd64.whl", hash = "sha256:7e1037073b1b7053ee74c3c6c0ada80f3501ec29d5f46e42669378eae6d4405a"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4385f12aa289d79419fede43f979e372f527892ac44a541b5446617e4406c468"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a58dd45cb865be0ce1d5ecc4cfc85cd8c6867bea66733623e54bd95131f473b6"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:ccccdd84912875e34c5ad2d06e1989d890d43af6c2242c6fcfa51556997af6cd"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:ea4adf02d23b437684cd388d557bf76e3afa72f7fed5bbc013482cc00c816948"},
+    {file = "regex-2020.4.4-cp37-cp37m-win32.whl", hash = "sha256:2294f8b70e058a2553cd009df003a20802ef75b3c629506be20687df0908177e"},
+    {file = "regex-2020.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:e91ba11da11cf770f389e47c3f5c30473e6d85e06d7fd9dcba0017d2867aab4a"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5635cd1ed0a12b4c42cce18a8d2fb53ff13ff537f09de5fd791e97de27b6400e"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:23069d9c07e115537f37270d1d5faea3e0bdded8279081c4d4d607a2ad393683"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c162a21e0da33eb3d31a3ac17a51db5e634fc347f650d271f0305d96601dc15b"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:fb95debbd1a824b2c4376932f2216cc186912e389bdb0e27147778cf6acb3f89"},
+    {file = "regex-2020.4.4-cp38-cp38-win32.whl", hash = "sha256:2a3bf8b48f8e37c3a40bb3f854bf0121c194e69a650b209628d951190b862de3"},
+    {file = "regex-2020.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3"},
+    {file = "regex-2020.4.4.tar.gz", hash = "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142"},
 ]
 requests = [
     {file = "requests-2.23.0-py2.py3-none-any.whl", hash = "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee"},
@@ -1368,8 +1366,8 @@ urllib3 = [
     {file = "urllib3-1.25.8.tar.gz", hash = "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.0.13-py2.py3-none-any.whl", hash = "sha256:87831f1070534b636fea2241dd66f3afe37ac9041bcca6d0af3215cdcfbf7d82"},
-    {file = "virtualenv-20.0.13.tar.gz", hash = "sha256:f3128d882383c503003130389bf892856341c1da12c881ae24d6358c82561b55"},
+    {file = "virtualenv-20.0.17-py2.py3-none-any.whl", hash = "sha256:00cfe8605fb97f5a59d52baab78e6070e72c12ca64f51151695407cc0eb8a431"},
+    {file = "virtualenv-20.0.17.tar.gz", hash = "sha256:c8364ec469084046c779c9a11ae6340094e8a0bf1d844330fc55c1cefe67c172"},
 ]
 wcwidth = [
     {file = "wcwidth-0.1.9-py2.py3-none-any.whl", hash = "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1"},

--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -65,10 +65,13 @@ services:
       traefik.http.middlewares.{{ _key }}-redirect2main.redirectregex.replacement: "https://${DOMAIN_PROD}/$${2}"
       traefik.http.routers.{{ _key }}-altdomains.entrypoints: "web-main"
       traefik.http.routers.{{ _key }}-altdomains.middlewares: "{{ _key }}-redirect2main"
-      traefik.http.routers.{{ _key }}-altdomains.rule: |
-        {%- for domain in domain_prod_alternatives %}
-        host(`${DOMAIN_PROD_ALT_{{ loop.index0 }}}`){% if not loop.last %} ||{% endif %}
-        {%- endfor %}
+      traefik.http.routers.{{ _key }}-altdomains.rule:
+        Host(
+          {%- for domain in domain_prod_alternatives -%}
+          `${DOMAIN_PROD_ALT_{{ loop.index0 }}}`
+          {%- if not loop.last %}, {% endif %}
+          {%- endfor -%}
+        )
       traefik.http.routers.{{ _key }}-altdomains.service: "{{ _key }}-main"
       traefik.http.routers.{{ _key }}-altdomains.tls: "true"
       traefik.http.routers.{{ _key }}-altdomains.tls.certresolver: "letsencrypt"
@@ -87,12 +90,12 @@ services:
       : "noindex, nofollow"
       traefik.http.routers.{{ _key }}-forbidden-crawlers.entrypoints: "web-main"
       traefik.http.routers.{{ _key }}-forbidden-crawlers.middlewares: "{{ _key }}-forbid-crawlers"
-      traefik.http.routers.{{ _key }}-forbidden-crawlers.rule: |
-        Host(`${DOMAIN_PROD}`) && (
-          {%- for path in paths_without_crawlers %}
-          Path(`{{ path }}`, `{{ path }}/{anything:.*}`)
-          {%- if not loop.last %} ||{% endif %}
-          {%- endfor %}
+      traefik.http.routers.{{ _key }}-forbidden-crawlers.rule:
+        Host(`${DOMAIN_PROD}`) && Path(
+          {%- for path in paths_without_crawlers -%}
+          `{{ path }}`, `{{ path }}/{anything:.*}`
+          {%- if not loop.last %}, {% endif %}
+          {%- endfor -%}
         )
       traefik.http.routers.{{ _key }}-forbidden-crawlers.service: "{{ _key }}-main"
       traefik.http.routers.{{ _key }}-forbidden-crawlers.tls: "true"

--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -43,17 +43,20 @@ services:
       {%- endfor %}
       {%- endif %}
       # Main service
-      ? traefik.http.middlewares.{{ _key }}-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.{{ _key }}-main-compress.compress: "true"
+      traefik.http.middlewares.{{ _key }}-buffering.buffering.retryExpression:
+        IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.{{ _key }}-compress.compress: "true"
       {%- if cidr_whitelist %}
-      ? traefik.http.middlewares.{{ _key }}-main-whitelist.IPWhiteList.sourceRange
+      ? traefik.http.middlewares.{{ _key }}-whitelist.IPWhiteList.sourceRange
       : {% for cidr in cidr_whitelist -%}
         {{ cidr }}{% if not loop.last %}, {% endif %}
         {%- endfor %}
       {%- endif %}
       traefik.http.routers.{{ _key }}-main.entrypoints: "web-main"
-      traefik.http.routers.{{ _key }}-main.middlewares: "{{ _key }}-main-compress,{{ _key }}-main-buffering{% if cidr_whitelist %},{{ _key }}-main-whitelist{% endif %}"
+      traefik.http.routers.{{ _key }}-main.middlewares:
+        {{ _key }}-buffering,
+        {{ _key }}-compress
+        {%- if cidr_whitelist %}, {{ _key }}-whitelist{% endif %}
       traefik.http.routers.{{ _key }}-main.rule: "host(`${DOMAIN_PROD}`)"
       traefik.http.routers.{{ _key }}-main.service: "{{ _key }}-main"
       traefik.http.routers.{{ _key }}-main.tls: "true"
@@ -64,7 +67,10 @@ services:
       traefik.http.middlewares.{{ _key }}-redirect2main.redirectregex.regex: "^https://([^/]+)/(.*)$$"
       traefik.http.middlewares.{{ _key }}-redirect2main.redirectregex.replacement: "https://${DOMAIN_PROD}/$${2}"
       traefik.http.routers.{{ _key }}-altdomains.entrypoints: "web-main"
-      traefik.http.routers.{{ _key }}-altdomains.middlewares: "{{ _key }}-redirect2main"
+      traefik.http.routers.{{ _key }}-altdomains.middlewares:
+        {{ _key }}-compress,
+        {{ _key }}-redirect2main
+        {%- if cidr_whitelist %}, {{ _key }}-whitelist{% endif %}
       traefik.http.routers.{{ _key }}-altdomains.rule:
         Host(
           {%- for domain in domain_prod_alternatives -%}
@@ -78,6 +84,9 @@ services:
       {%- endif %}
       # Longpolling service
       traefik.http.routers.{{ _key }}-longpolling.entrypoints: "web-main"
+      {%- if cidr_whitelist %}
+      traefik.http.routers.{{ _key }}-longpolling.middlewares: {{ _key }}-whitelist
+      {%- endif %}
       traefik.http.routers.{{ _key }}-longpolling.rule:
         "host(`${DOMAIN_PROD}`) && pathprefix(`/longpolling/`)"
       traefik.http.routers.{{ _key }}-longpolling.service: "{{ _key }}-longpolling"
@@ -89,7 +98,11 @@ services:
       ? traefik.http.middlewares.{{ _key }}-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
       : "noindex, nofollow"
       traefik.http.routers.{{ _key }}-forbidden-crawlers.entrypoints: "web-main"
-      traefik.http.routers.{{ _key }}-forbidden-crawlers.middlewares: "{{ _key }}-forbid-crawlers"
+      traefik.http.routers.{{ _key }}-forbidden-crawlers.middlewares:
+        {{ _key }}-buffering,
+        {{ _key }}-compress,
+        {{ _key }}-forbid-crawlers
+        {%- if cidr_whitelist %}, {{ _key }}-whitelist{% endif %}"
       traefik.http.routers.{{ _key }}-forbidden-crawlers.rule:
         Host(`${DOMAIN_PROD}`) && Path(
           {%- for path in paths_without_crawlers -%}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 [tool.poetry.dependencies]
 # TODO Use versioned copier after v3.0.0 is released
 # HACK https://github.com/pykong/copier/issues/112
-copier = "^3.0.2"
+copier = "^3.0.6"
 plumbum = "^1.6.8"
 python = "^3.6"
 

--- a/tasks.py
+++ b/tasks.py
@@ -88,7 +88,16 @@ def test(c, verbose=False):
 
 @task(develop)
 def update_test_samples(c):
-    """Update default scaffolding renderings."""
+    """Update test samples renderings.
+
+    Since this project is just a template, some render results are stored as
+    tests to be able to check the templates produce the right results.
+
+    However, when something changes, the samples must be properly updated and
+    reviewed to make sure they are still OK.
+
+    This job updates all those samples.
+    """
     # Make sure git repo is clean
     try:
         c.run("git diff --quiet --exit-code")
@@ -129,4 +138,12 @@ def update_test_samples(c):
             )
             fd.write(c.run(f"diff {own} {mqt}", warn=True).stdout)
     shutil.rmtree(samples / "cidr-whitelist" / ".venv")
-    c.run("pre-commit run -a", warn=True)
+    c.run(
+        "poetry run copier -fr HEAD -x '**' -x '!prod.yaml' "
+        "-d domain_prod=www.example.com "
+        "-d domain_prod_alternatives='[old.example.com, example.com, example.org, www.example.org]' "
+        f"copy . {samples /'alt-domains'}",
+        warn=True,
+    )
+    shutil.rmtree(samples / "alt-domains" / ".venv")
+    c.run("poetry run pre-commit run -a", warn=True)

--- a/test.yaml.jinja
+++ b/test.yaml.jinja
@@ -29,27 +29,33 @@ services:
       traefik.longpolling.frontend.rule: "Host:${DOMAIN_TEST};PathPrefix:/longpolling/"
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
       # Forbid crawlers
-      ? traefik.http.middlewares.{{ _key }}-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
-      : "noindex, nofollow"
+      traefik.http.middlewares.{{ _key }}-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag:
+        noindex, nofollow
       # Main service
-      ? traefik.http.middlewares.{{ _key }}-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.{{ _key }}-main-compress.compress: "true"
+      traefik.http.middlewares.{{ _key }}-buffering.buffering.retryExpression:
+        IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.{{ _key }}-compress.compress: "true"
       {%- if cidr_whitelist %}
-      ? traefik.http.middlewares.{{ _key }}-main-whitelist.IPWhiteList.sourceRange
+      ? traefik.http.middlewares.{{ _key }}-whitelist.IPWhiteList.sourceRange
       : {% for cidr in cidr_whitelist -%}
         {{ cidr }}{% if not loop.last %}, {% endif %}
         {%- endfor %}
       {%- endif %}
       traefik.http.routers.{{ _key }}-main.entrypoints: "web-main"
-      traefik.http.routers.{{ _key }}-main.middlewares: "{{ _key }}-main-compress,{{ _key }}-main-buffering,{{ _key }}-forbid-crawlers{% if cidr_whitelist %},{{ _key }}-main-whitelist{% endif %}"
+      traefik.http.routers.{{ _key }}-main.middlewares:
+        {{ _key }}-buffering,
+        {{ _key }}-compress,
+        {{ _key }}-forbid-crawlers
+        {%- if cidr_whitelist %}, {{ _key }}-whitelist{% endif %}
       traefik.http.routers.{{ _key }}-main.rule: "host(`${DOMAIN_TEST}`)"
       traefik.http.routers.{{ _key }}-main.service: "{{ _key }}-main"
       traefik.http.routers.{{ _key }}-main.tls.certresolver: "letsencrypt"
       traefik.http.services.{{ _key }}-main.loadbalancer.server.port: 8069
       # Longpolling service
       traefik.http.routers.{{ _key }}-longpolling.entrypoints: "web-main"
-      traefik.http.routers.{{ _key }}-longpolling.middlewares: "{{ _key }}-forbid-crawlers"
+      traefik.http.routers.{{ _key }}-longpolling.middlewares:
+        {{ _key }}-forbid-crawlers
+        {%- if cidr_whitelist %}, {{ _key }}-whitelist{% endif %}
       traefik.http.routers.{{ _key }}-longpolling.rule:
         "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
       traefik.http.routers.{{ _key }}-longpolling.service: "{{ _key }}-longpolling"
@@ -87,6 +93,19 @@ services:
       traefik.frontend.passHostHeader: "true"
       traefik.frontend.rule: "Host:${DOMAIN_TEST};PathPrefixStrip:/smtpfake/"
       traefik.port: "8025"
+      # Mailhog service
+      traefik.http.middlewares.{{ _key }}-mailhog-stripprefix.stripPrefix.prefixes: /smtpfake
+      traefik.http.routers.{{ _key }}-mailhog.entrypoints: web-main
+      traefik.http.routers.{{ _key }}-mailhog.middlewares:
+        {{ _key }}-buffering,
+        {{ _key }}-compress,
+        {{ _key }}-forbid-crawlers,
+        {{ _key }}-mailhog-stripprefix
+        {%- if cidr_whitelist %}, {{ _key }}-whitelist{% endif %}
+      traefik.http.routers.{{ _key }}-mailhog.rule: Host(`${DOMAIN_TEST}`) && PathPrefix(`/smtpfake/`)
+      traefik.http.routers.{{ _key }}-mailhog.service: {{ _key }}-mailhog
+      traefik.http.routers.{{ _key }}-mailhog.tls.certresolver: letsencrypt
+      traefik.http.services.{{ _key }}-mailhog.loadbalancer.server.port: 8025
     {%- endif %}
     volumes:
       - "smtpconf:/etc/mailhog:ro,z"

--- a/tests/default_settings/v10.0/prod.yaml
+++ b/tests/default_settings/v10.0/prod.yaml
@@ -22,11 +22,12 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_PROD}"
       traefik.forbid-crawlers.frontend.rule: "Host:${DOMAIN_PROD};PathPrefix:/web,/web/{anything:.*},/website/info,/website/info/{anything:.*}"
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-10-0-prod-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-10-0-prod-main-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-10-0-prod-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-10-0-prod-compress.compress: "true"
       traefik.http.routers.myproject-odoo-10-0-prod-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-10-0-prod-main.middlewares: "myproject-odoo-10-0-prod-main-compress,myproject-odoo-10-0-prod-main-buffering"
+      traefik.http.routers.myproject-odoo-10-0-prod-main.middlewares:
+        myproject-odoo-10-0-prod-buffering, myproject-odoo-10-0-prod-compress
       traefik.http.routers.myproject-odoo-10-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
       traefik.http.routers.myproject-odoo-10-0-prod-main.service: "myproject-odoo-10-0-prod-main"
       traefik.http.routers.myproject-odoo-10-0-prod-main.tls: "true"
@@ -44,7 +45,9 @@ services:
       ? traefik.http.middlewares.myproject-odoo-10-0-prod-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-10-0-prod-forbidden-crawlers.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-10-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-10-0-prod-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-10-0-prod-forbidden-crawlers.middlewares:
+        myproject-odoo-10-0-prod-buffering, myproject-odoo-10-0-prod-compress,
+        myproject-odoo-10-0-prod-forbid-crawlers"
       traefik.http.routers.myproject-odoo-10-0-prod-forbidden-crawlers.rule:
         Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
         `/website/info/{anything:.*}`)

--- a/tests/default_settings/v10.0/prod.yaml
+++ b/tests/default_settings/v10.0/prod.yaml
@@ -45,11 +45,9 @@ services:
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-10-0-prod-forbidden-crawlers.entrypoints: "web-main"
       traefik.http.routers.myproject-odoo-10-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-10-0-prod-forbid-crawlers"
-      traefik.http.routers.myproject-odoo-10-0-prod-forbidden-crawlers.rule: |
-        Host(`${DOMAIN_PROD}`) && (
-          Path(`/web`, `/web/{anything:.*}`) ||
-          Path(`/website/info`, `/website/info/{anything:.*}`)
-        )
+      traefik.http.routers.myproject-odoo-10-0-prod-forbidden-crawlers.rule:
+        Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
+        `/website/info/{anything:.*}`)
       traefik.http.routers.myproject-odoo-10-0-prod-forbidden-crawlers.service: "myproject-odoo-10-0-prod-main"
       traefik.http.routers.myproject-odoo-10-0-prod-forbidden-crawlers.tls: "true"
       traefik.http.routers.myproject-odoo-10-0-prod-forbidden-crawlers.tls.certresolver: "letsencrypt"

--- a/tests/default_settings/v10.0/test.yaml
+++ b/tests/default_settings/v10.0/test.yaml
@@ -28,20 +28,22 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
       # Forbid crawlers
       ? traefik.http.middlewares.myproject-odoo-10-0-test-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
-      : "noindex, nofollow"
+      : noindex, nofollow
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-10-0-test-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-10-0-test-main-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-10-0-test-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-10-0-test-compress.compress: "true"
       traefik.http.routers.myproject-odoo-10-0-test-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-10-0-test-main.middlewares: "myproject-odoo-10-0-test-main-compress,myproject-odoo-10-0-test-main-buffering,myproject-odoo-10-0-test-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-10-0-test-main.middlewares:
+        myproject-odoo-10-0-test-buffering, myproject-odoo-10-0-test-compress,
+        myproject-odoo-10-0-test-forbid-crawlers
       traefik.http.routers.myproject-odoo-10-0-test-main.rule: "host(`${DOMAIN_TEST}`)"
       traefik.http.routers.myproject-odoo-10-0-test-main.service: "myproject-odoo-10-0-test-main"
       traefik.http.routers.myproject-odoo-10-0-test-main.tls.certresolver: "letsencrypt"
       traefik.http.services.myproject-odoo-10-0-test-main.loadbalancer.server.port: 8069
       # Longpolling service
       traefik.http.routers.myproject-odoo-10-0-test-longpolling.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-10-0-test-longpolling.middlewares: "myproject-odoo-10-0-test-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-10-0-test-longpolling.middlewares: myproject-odoo-10-0-test-forbid-crawlers
       traefik.http.routers.myproject-odoo-10-0-test-longpolling.rule:
         "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
       traefik.http.routers.myproject-odoo-10-0-test-longpolling.service: "myproject-odoo-10-0-test-longpolling"
@@ -77,6 +79,18 @@ services:
       traefik.frontend.passHostHeader: "true"
       traefik.frontend.rule: "Host:${DOMAIN_TEST};PathPrefixStrip:/smtpfake/"
       traefik.port: "8025"
+      # Mailhog service
+      traefik.http.middlewares.myproject-odoo-10-0-test-mailhog-stripprefix.stripPrefix.prefixes: /smtpfake
+      traefik.http.routers.myproject-odoo-10-0-test-mailhog.entrypoints: web-main
+      traefik.http.routers.myproject-odoo-10-0-test-mailhog.middlewares:
+        myproject-odoo-10-0-test-buffering, myproject-odoo-10-0-test-compress,
+        myproject-odoo-10-0-test-forbid-crawlers,
+        myproject-odoo-10-0-test-mailhog-stripprefix
+      traefik.http.routers.myproject-odoo-10-0-test-mailhog.rule:
+        Host(`${DOMAIN_TEST}`) && PathPrefix(`/smtpfake/`)
+      traefik.http.routers.myproject-odoo-10-0-test-mailhog.service: myproject-odoo-10-0-test-mailhog
+      traefik.http.routers.myproject-odoo-10-0-test-mailhog.tls.certresolver: letsencrypt
+      traefik.http.services.myproject-odoo-10-0-test-mailhog.loadbalancer.server.port: 8025
     volumes:
       - "smtpconf:/etc/mailhog:ro,z"
     entrypoint: [sh, -c]

--- a/tests/default_settings/v11.0/prod.yaml
+++ b/tests/default_settings/v11.0/prod.yaml
@@ -22,11 +22,12 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_PROD}"
       traefik.forbid-crawlers.frontend.rule: "Host:${DOMAIN_PROD};PathPrefix:/web,/web/{anything:.*},/website/info,/website/info/{anything:.*}"
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-11-0-prod-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-11-0-prod-main-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-11-0-prod-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-11-0-prod-compress.compress: "true"
       traefik.http.routers.myproject-odoo-11-0-prod-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-11-0-prod-main.middlewares: "myproject-odoo-11-0-prod-main-compress,myproject-odoo-11-0-prod-main-buffering"
+      traefik.http.routers.myproject-odoo-11-0-prod-main.middlewares:
+        myproject-odoo-11-0-prod-buffering, myproject-odoo-11-0-prod-compress
       traefik.http.routers.myproject-odoo-11-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
       traefik.http.routers.myproject-odoo-11-0-prod-main.service: "myproject-odoo-11-0-prod-main"
       traefik.http.routers.myproject-odoo-11-0-prod-main.tls: "true"
@@ -44,7 +45,9 @@ services:
       ? traefik.http.middlewares.myproject-odoo-11-0-prod-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-11-0-prod-forbidden-crawlers.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-11-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-11-0-prod-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-11-0-prod-forbidden-crawlers.middlewares:
+        myproject-odoo-11-0-prod-buffering, myproject-odoo-11-0-prod-compress,
+        myproject-odoo-11-0-prod-forbid-crawlers"
       traefik.http.routers.myproject-odoo-11-0-prod-forbidden-crawlers.rule:
         Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
         `/website/info/{anything:.*}`)

--- a/tests/default_settings/v11.0/prod.yaml
+++ b/tests/default_settings/v11.0/prod.yaml
@@ -45,11 +45,9 @@ services:
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-11-0-prod-forbidden-crawlers.entrypoints: "web-main"
       traefik.http.routers.myproject-odoo-11-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-11-0-prod-forbid-crawlers"
-      traefik.http.routers.myproject-odoo-11-0-prod-forbidden-crawlers.rule: |
-        Host(`${DOMAIN_PROD}`) && (
-          Path(`/web`, `/web/{anything:.*}`) ||
-          Path(`/website/info`, `/website/info/{anything:.*}`)
-        )
+      traefik.http.routers.myproject-odoo-11-0-prod-forbidden-crawlers.rule:
+        Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
+        `/website/info/{anything:.*}`)
       traefik.http.routers.myproject-odoo-11-0-prod-forbidden-crawlers.service: "myproject-odoo-11-0-prod-main"
       traefik.http.routers.myproject-odoo-11-0-prod-forbidden-crawlers.tls: "true"
       traefik.http.routers.myproject-odoo-11-0-prod-forbidden-crawlers.tls.certresolver: "letsencrypt"

--- a/tests/default_settings/v11.0/test.yaml
+++ b/tests/default_settings/v11.0/test.yaml
@@ -28,20 +28,22 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
       # Forbid crawlers
       ? traefik.http.middlewares.myproject-odoo-11-0-test-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
-      : "noindex, nofollow"
+      : noindex, nofollow
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-11-0-test-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-11-0-test-main-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-11-0-test-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-11-0-test-compress.compress: "true"
       traefik.http.routers.myproject-odoo-11-0-test-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-11-0-test-main.middlewares: "myproject-odoo-11-0-test-main-compress,myproject-odoo-11-0-test-main-buffering,myproject-odoo-11-0-test-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-11-0-test-main.middlewares:
+        myproject-odoo-11-0-test-buffering, myproject-odoo-11-0-test-compress,
+        myproject-odoo-11-0-test-forbid-crawlers
       traefik.http.routers.myproject-odoo-11-0-test-main.rule: "host(`${DOMAIN_TEST}`)"
       traefik.http.routers.myproject-odoo-11-0-test-main.service: "myproject-odoo-11-0-test-main"
       traefik.http.routers.myproject-odoo-11-0-test-main.tls.certresolver: "letsencrypt"
       traefik.http.services.myproject-odoo-11-0-test-main.loadbalancer.server.port: 8069
       # Longpolling service
       traefik.http.routers.myproject-odoo-11-0-test-longpolling.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-11-0-test-longpolling.middlewares: "myproject-odoo-11-0-test-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-11-0-test-longpolling.middlewares: myproject-odoo-11-0-test-forbid-crawlers
       traefik.http.routers.myproject-odoo-11-0-test-longpolling.rule:
         "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
       traefik.http.routers.myproject-odoo-11-0-test-longpolling.service: "myproject-odoo-11-0-test-longpolling"
@@ -77,6 +79,18 @@ services:
       traefik.frontend.passHostHeader: "true"
       traefik.frontend.rule: "Host:${DOMAIN_TEST};PathPrefixStrip:/smtpfake/"
       traefik.port: "8025"
+      # Mailhog service
+      traefik.http.middlewares.myproject-odoo-11-0-test-mailhog-stripprefix.stripPrefix.prefixes: /smtpfake
+      traefik.http.routers.myproject-odoo-11-0-test-mailhog.entrypoints: web-main
+      traefik.http.routers.myproject-odoo-11-0-test-mailhog.middlewares:
+        myproject-odoo-11-0-test-buffering, myproject-odoo-11-0-test-compress,
+        myproject-odoo-11-0-test-forbid-crawlers,
+        myproject-odoo-11-0-test-mailhog-stripprefix
+      traefik.http.routers.myproject-odoo-11-0-test-mailhog.rule:
+        Host(`${DOMAIN_TEST}`) && PathPrefix(`/smtpfake/`)
+      traefik.http.routers.myproject-odoo-11-0-test-mailhog.service: myproject-odoo-11-0-test-mailhog
+      traefik.http.routers.myproject-odoo-11-0-test-mailhog.tls.certresolver: letsencrypt
+      traefik.http.services.myproject-odoo-11-0-test-mailhog.loadbalancer.server.port: 8025
     volumes:
       - "smtpconf:/etc/mailhog:ro,z"
     entrypoint: [sh, -c]

--- a/tests/default_settings/v12.0/prod.yaml
+++ b/tests/default_settings/v12.0/prod.yaml
@@ -22,11 +22,12 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_PROD}"
       traefik.forbid-crawlers.frontend.rule: "Host:${DOMAIN_PROD};PathPrefix:/web,/web/{anything:.*},/website/info,/website/info/{anything:.*}"
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-12-0-prod-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-12-0-prod-main-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-12-0-prod-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-12-0-prod-compress.compress: "true"
       traefik.http.routers.myproject-odoo-12-0-prod-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-12-0-prod-main.middlewares: "myproject-odoo-12-0-prod-main-compress,myproject-odoo-12-0-prod-main-buffering"
+      traefik.http.routers.myproject-odoo-12-0-prod-main.middlewares:
+        myproject-odoo-12-0-prod-buffering, myproject-odoo-12-0-prod-compress
       traefik.http.routers.myproject-odoo-12-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
       traefik.http.routers.myproject-odoo-12-0-prod-main.service: "myproject-odoo-12-0-prod-main"
       traefik.http.routers.myproject-odoo-12-0-prod-main.tls: "true"
@@ -44,7 +45,9 @@ services:
       ? traefik.http.middlewares.myproject-odoo-12-0-prod-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-12-0-prod-forbidden-crawlers.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-12-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-12-0-prod-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-12-0-prod-forbidden-crawlers.middlewares:
+        myproject-odoo-12-0-prod-buffering, myproject-odoo-12-0-prod-compress,
+        myproject-odoo-12-0-prod-forbid-crawlers"
       traefik.http.routers.myproject-odoo-12-0-prod-forbidden-crawlers.rule:
         Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
         `/website/info/{anything:.*}`)

--- a/tests/default_settings/v12.0/prod.yaml
+++ b/tests/default_settings/v12.0/prod.yaml
@@ -45,11 +45,9 @@ services:
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-12-0-prod-forbidden-crawlers.entrypoints: "web-main"
       traefik.http.routers.myproject-odoo-12-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-12-0-prod-forbid-crawlers"
-      traefik.http.routers.myproject-odoo-12-0-prod-forbidden-crawlers.rule: |
-        Host(`${DOMAIN_PROD}`) && (
-          Path(`/web`, `/web/{anything:.*}`) ||
-          Path(`/website/info`, `/website/info/{anything:.*}`)
-        )
+      traefik.http.routers.myproject-odoo-12-0-prod-forbidden-crawlers.rule:
+        Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
+        `/website/info/{anything:.*}`)
       traefik.http.routers.myproject-odoo-12-0-prod-forbidden-crawlers.service: "myproject-odoo-12-0-prod-main"
       traefik.http.routers.myproject-odoo-12-0-prod-forbidden-crawlers.tls: "true"
       traefik.http.routers.myproject-odoo-12-0-prod-forbidden-crawlers.tls.certresolver: "letsencrypt"

--- a/tests/default_settings/v12.0/test.yaml
+++ b/tests/default_settings/v12.0/test.yaml
@@ -28,20 +28,22 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
       # Forbid crawlers
       ? traefik.http.middlewares.myproject-odoo-12-0-test-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
-      : "noindex, nofollow"
+      : noindex, nofollow
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-12-0-test-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-12-0-test-main-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-12-0-test-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-12-0-test-compress.compress: "true"
       traefik.http.routers.myproject-odoo-12-0-test-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-12-0-test-main.middlewares: "myproject-odoo-12-0-test-main-compress,myproject-odoo-12-0-test-main-buffering,myproject-odoo-12-0-test-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-12-0-test-main.middlewares:
+        myproject-odoo-12-0-test-buffering, myproject-odoo-12-0-test-compress,
+        myproject-odoo-12-0-test-forbid-crawlers
       traefik.http.routers.myproject-odoo-12-0-test-main.rule: "host(`${DOMAIN_TEST}`)"
       traefik.http.routers.myproject-odoo-12-0-test-main.service: "myproject-odoo-12-0-test-main"
       traefik.http.routers.myproject-odoo-12-0-test-main.tls.certresolver: "letsencrypt"
       traefik.http.services.myproject-odoo-12-0-test-main.loadbalancer.server.port: 8069
       # Longpolling service
       traefik.http.routers.myproject-odoo-12-0-test-longpolling.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-12-0-test-longpolling.middlewares: "myproject-odoo-12-0-test-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-12-0-test-longpolling.middlewares: myproject-odoo-12-0-test-forbid-crawlers
       traefik.http.routers.myproject-odoo-12-0-test-longpolling.rule:
         "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
       traefik.http.routers.myproject-odoo-12-0-test-longpolling.service: "myproject-odoo-12-0-test-longpolling"
@@ -77,6 +79,18 @@ services:
       traefik.frontend.passHostHeader: "true"
       traefik.frontend.rule: "Host:${DOMAIN_TEST};PathPrefixStrip:/smtpfake/"
       traefik.port: "8025"
+      # Mailhog service
+      traefik.http.middlewares.myproject-odoo-12-0-test-mailhog-stripprefix.stripPrefix.prefixes: /smtpfake
+      traefik.http.routers.myproject-odoo-12-0-test-mailhog.entrypoints: web-main
+      traefik.http.routers.myproject-odoo-12-0-test-mailhog.middlewares:
+        myproject-odoo-12-0-test-buffering, myproject-odoo-12-0-test-compress,
+        myproject-odoo-12-0-test-forbid-crawlers,
+        myproject-odoo-12-0-test-mailhog-stripprefix
+      traefik.http.routers.myproject-odoo-12-0-test-mailhog.rule:
+        Host(`${DOMAIN_TEST}`) && PathPrefix(`/smtpfake/`)
+      traefik.http.routers.myproject-odoo-12-0-test-mailhog.service: myproject-odoo-12-0-test-mailhog
+      traefik.http.routers.myproject-odoo-12-0-test-mailhog.tls.certresolver: letsencrypt
+      traefik.http.services.myproject-odoo-12-0-test-mailhog.loadbalancer.server.port: 8025
     volumes:
       - "smtpconf:/etc/mailhog:ro,z"
     entrypoint: [sh, -c]

--- a/tests/default_settings/v13.0/prod.yaml
+++ b/tests/default_settings/v13.0/prod.yaml
@@ -45,11 +45,9 @@ services:
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.entrypoints: "web-main"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-13-0-prod-forbid-crawlers"
-      traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.rule: |
-        Host(`${DOMAIN_PROD}`) && (
-          Path(`/web`, `/web/{anything:.*}`) ||
-          Path(`/website/info`, `/website/info/{anything:.*}`)
-        )
+      traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.rule:
+        Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
+        `/website/info/{anything:.*}`)
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.service: "myproject-odoo-13-0-prod-main"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.tls: "true"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.tls.certresolver: "letsencrypt"

--- a/tests/default_settings/v13.0/prod.yaml
+++ b/tests/default_settings/v13.0/prod.yaml
@@ -22,11 +22,12 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_PROD}"
       traefik.forbid-crawlers.frontend.rule: "Host:${DOMAIN_PROD};PathPrefix:/web,/web/{anything:.*},/website/info,/website/info/{anything:.*}"
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-13-0-prod-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-13-0-prod-main-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-13-0-prod-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-13-0-prod-compress.compress: "true"
       traefik.http.routers.myproject-odoo-13-0-prod-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-13-0-prod-main.middlewares: "myproject-odoo-13-0-prod-main-compress,myproject-odoo-13-0-prod-main-buffering"
+      traefik.http.routers.myproject-odoo-13-0-prod-main.middlewares:
+        myproject-odoo-13-0-prod-buffering, myproject-odoo-13-0-prod-compress
       traefik.http.routers.myproject-odoo-13-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
       traefik.http.routers.myproject-odoo-13-0-prod-main.service: "myproject-odoo-13-0-prod-main"
       traefik.http.routers.myproject-odoo-13-0-prod-main.tls: "true"
@@ -44,7 +45,9 @@ services:
       ? traefik.http.middlewares.myproject-odoo-13-0-prod-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-13-0-prod-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.middlewares:
+        myproject-odoo-13-0-prod-buffering, myproject-odoo-13-0-prod-compress,
+        myproject-odoo-13-0-prod-forbid-crawlers"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.rule:
         Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
         `/website/info/{anything:.*}`)

--- a/tests/default_settings/v13.0/test.yaml
+++ b/tests/default_settings/v13.0/test.yaml
@@ -28,20 +28,22 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
       # Forbid crawlers
       ? traefik.http.middlewares.myproject-odoo-13-0-test-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
-      : "noindex, nofollow"
+      : noindex, nofollow
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-13-0-test-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-13-0-test-main-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-13-0-test-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-13-0-test-compress.compress: "true"
       traefik.http.routers.myproject-odoo-13-0-test-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-13-0-test-main.middlewares: "myproject-odoo-13-0-test-main-compress,myproject-odoo-13-0-test-main-buffering,myproject-odoo-13-0-test-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-13-0-test-main.middlewares:
+        myproject-odoo-13-0-test-buffering, myproject-odoo-13-0-test-compress,
+        myproject-odoo-13-0-test-forbid-crawlers
       traefik.http.routers.myproject-odoo-13-0-test-main.rule: "host(`${DOMAIN_TEST}`)"
       traefik.http.routers.myproject-odoo-13-0-test-main.service: "myproject-odoo-13-0-test-main"
       traefik.http.routers.myproject-odoo-13-0-test-main.tls.certresolver: "letsencrypt"
       traefik.http.services.myproject-odoo-13-0-test-main.loadbalancer.server.port: 8069
       # Longpolling service
       traefik.http.routers.myproject-odoo-13-0-test-longpolling.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-13-0-test-longpolling.middlewares: "myproject-odoo-13-0-test-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-13-0-test-longpolling.middlewares: myproject-odoo-13-0-test-forbid-crawlers
       traefik.http.routers.myproject-odoo-13-0-test-longpolling.rule:
         "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
       traefik.http.routers.myproject-odoo-13-0-test-longpolling.service: "myproject-odoo-13-0-test-longpolling"
@@ -77,6 +79,18 @@ services:
       traefik.frontend.passHostHeader: "true"
       traefik.frontend.rule: "Host:${DOMAIN_TEST};PathPrefixStrip:/smtpfake/"
       traefik.port: "8025"
+      # Mailhog service
+      traefik.http.middlewares.myproject-odoo-13-0-test-mailhog-stripprefix.stripPrefix.prefixes: /smtpfake
+      traefik.http.routers.myproject-odoo-13-0-test-mailhog.entrypoints: web-main
+      traefik.http.routers.myproject-odoo-13-0-test-mailhog.middlewares:
+        myproject-odoo-13-0-test-buffering, myproject-odoo-13-0-test-compress,
+        myproject-odoo-13-0-test-forbid-crawlers,
+        myproject-odoo-13-0-test-mailhog-stripprefix
+      traefik.http.routers.myproject-odoo-13-0-test-mailhog.rule:
+        Host(`${DOMAIN_TEST}`) && PathPrefix(`/smtpfake/`)
+      traefik.http.routers.myproject-odoo-13-0-test-mailhog.service: myproject-odoo-13-0-test-mailhog
+      traefik.http.routers.myproject-odoo-13-0-test-mailhog.tls.certresolver: letsencrypt
+      traefik.http.services.myproject-odoo-13-0-test-mailhog.loadbalancer.server.port: 8025
     volumes:
       - "smtpconf:/etc/mailhog:ro,z"
     entrypoint: [sh, -c]

--- a/tests/default_settings/v7.0/prod.yaml
+++ b/tests/default_settings/v7.0/prod.yaml
@@ -45,11 +45,9 @@ services:
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-7-0-prod-forbidden-crawlers.entrypoints: "web-main"
       traefik.http.routers.myproject-odoo-7-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-7-0-prod-forbid-crawlers"
-      traefik.http.routers.myproject-odoo-7-0-prod-forbidden-crawlers.rule: |
-        Host(`${DOMAIN_PROD}`) && (
-          Path(`/web`, `/web/{anything:.*}`) ||
-          Path(`/website/info`, `/website/info/{anything:.*}`)
-        )
+      traefik.http.routers.myproject-odoo-7-0-prod-forbidden-crawlers.rule:
+        Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
+        `/website/info/{anything:.*}`)
       traefik.http.routers.myproject-odoo-7-0-prod-forbidden-crawlers.service: "myproject-odoo-7-0-prod-main"
       traefik.http.routers.myproject-odoo-7-0-prod-forbidden-crawlers.tls: "true"
       traefik.http.routers.myproject-odoo-7-0-prod-forbidden-crawlers.tls.certresolver: "letsencrypt"

--- a/tests/default_settings/v7.0/prod.yaml
+++ b/tests/default_settings/v7.0/prod.yaml
@@ -22,11 +22,12 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_PROD}"
       traefik.forbid-crawlers.frontend.rule: "Host:${DOMAIN_PROD};PathPrefix:/web,/web/{anything:.*},/website/info,/website/info/{anything:.*}"
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-7-0-prod-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-7-0-prod-main-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-7-0-prod-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-7-0-prod-compress.compress: "true"
       traefik.http.routers.myproject-odoo-7-0-prod-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-7-0-prod-main.middlewares: "myproject-odoo-7-0-prod-main-compress,myproject-odoo-7-0-prod-main-buffering"
+      traefik.http.routers.myproject-odoo-7-0-prod-main.middlewares:
+        myproject-odoo-7-0-prod-buffering, myproject-odoo-7-0-prod-compress
       traefik.http.routers.myproject-odoo-7-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
       traefik.http.routers.myproject-odoo-7-0-prod-main.service: "myproject-odoo-7-0-prod-main"
       traefik.http.routers.myproject-odoo-7-0-prod-main.tls: "true"
@@ -44,7 +45,9 @@ services:
       ? traefik.http.middlewares.myproject-odoo-7-0-prod-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-7-0-prod-forbidden-crawlers.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-7-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-7-0-prod-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-7-0-prod-forbidden-crawlers.middlewares:
+        myproject-odoo-7-0-prod-buffering, myproject-odoo-7-0-prod-compress,
+        myproject-odoo-7-0-prod-forbid-crawlers"
       traefik.http.routers.myproject-odoo-7-0-prod-forbidden-crawlers.rule:
         Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
         `/website/info/{anything:.*}`)

--- a/tests/default_settings/v7.0/test.yaml
+++ b/tests/default_settings/v7.0/test.yaml
@@ -28,20 +28,22 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
       # Forbid crawlers
       ? traefik.http.middlewares.myproject-odoo-7-0-test-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
-      : "noindex, nofollow"
+      : noindex, nofollow
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-7-0-test-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-7-0-test-main-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-7-0-test-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-7-0-test-compress.compress: "true"
       traefik.http.routers.myproject-odoo-7-0-test-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-7-0-test-main.middlewares: "myproject-odoo-7-0-test-main-compress,myproject-odoo-7-0-test-main-buffering,myproject-odoo-7-0-test-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-7-0-test-main.middlewares:
+        myproject-odoo-7-0-test-buffering, myproject-odoo-7-0-test-compress,
+        myproject-odoo-7-0-test-forbid-crawlers
       traefik.http.routers.myproject-odoo-7-0-test-main.rule: "host(`${DOMAIN_TEST}`)"
       traefik.http.routers.myproject-odoo-7-0-test-main.service: "myproject-odoo-7-0-test-main"
       traefik.http.routers.myproject-odoo-7-0-test-main.tls.certresolver: "letsencrypt"
       traefik.http.services.myproject-odoo-7-0-test-main.loadbalancer.server.port: 8069
       # Longpolling service
       traefik.http.routers.myproject-odoo-7-0-test-longpolling.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-7-0-test-longpolling.middlewares: "myproject-odoo-7-0-test-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-7-0-test-longpolling.middlewares: myproject-odoo-7-0-test-forbid-crawlers
       traefik.http.routers.myproject-odoo-7-0-test-longpolling.rule:
         "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
       traefik.http.routers.myproject-odoo-7-0-test-longpolling.service: "myproject-odoo-7-0-test-longpolling"
@@ -77,6 +79,18 @@ services:
       traefik.frontend.passHostHeader: "true"
       traefik.frontend.rule: "Host:${DOMAIN_TEST};PathPrefixStrip:/smtpfake/"
       traefik.port: "8025"
+      # Mailhog service
+      traefik.http.middlewares.myproject-odoo-7-0-test-mailhog-stripprefix.stripPrefix.prefixes: /smtpfake
+      traefik.http.routers.myproject-odoo-7-0-test-mailhog.entrypoints: web-main
+      traefik.http.routers.myproject-odoo-7-0-test-mailhog.middlewares:
+        myproject-odoo-7-0-test-buffering, myproject-odoo-7-0-test-compress,
+        myproject-odoo-7-0-test-forbid-crawlers,
+        myproject-odoo-7-0-test-mailhog-stripprefix
+      traefik.http.routers.myproject-odoo-7-0-test-mailhog.rule:
+        Host(`${DOMAIN_TEST}`) && PathPrefix(`/smtpfake/`)
+      traefik.http.routers.myproject-odoo-7-0-test-mailhog.service: myproject-odoo-7-0-test-mailhog
+      traefik.http.routers.myproject-odoo-7-0-test-mailhog.tls.certresolver: letsencrypt
+      traefik.http.services.myproject-odoo-7-0-test-mailhog.loadbalancer.server.port: 8025
     volumes:
       - "smtpconf:/etc/mailhog:ro,z"
     entrypoint: [sh, -c]

--- a/tests/default_settings/v8.0/prod.yaml
+++ b/tests/default_settings/v8.0/prod.yaml
@@ -45,11 +45,9 @@ services:
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-8-0-prod-forbidden-crawlers.entrypoints: "web-main"
       traefik.http.routers.myproject-odoo-8-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-8-0-prod-forbid-crawlers"
-      traefik.http.routers.myproject-odoo-8-0-prod-forbidden-crawlers.rule: |
-        Host(`${DOMAIN_PROD}`) && (
-          Path(`/web`, `/web/{anything:.*}`) ||
-          Path(`/website/info`, `/website/info/{anything:.*}`)
-        )
+      traefik.http.routers.myproject-odoo-8-0-prod-forbidden-crawlers.rule:
+        Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
+        `/website/info/{anything:.*}`)
       traefik.http.routers.myproject-odoo-8-0-prod-forbidden-crawlers.service: "myproject-odoo-8-0-prod-main"
       traefik.http.routers.myproject-odoo-8-0-prod-forbidden-crawlers.tls: "true"
       traefik.http.routers.myproject-odoo-8-0-prod-forbidden-crawlers.tls.certresolver: "letsencrypt"

--- a/tests/default_settings/v8.0/prod.yaml
+++ b/tests/default_settings/v8.0/prod.yaml
@@ -22,11 +22,12 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_PROD}"
       traefik.forbid-crawlers.frontend.rule: "Host:${DOMAIN_PROD};PathPrefix:/web,/web/{anything:.*},/website/info,/website/info/{anything:.*}"
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-8-0-prod-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-8-0-prod-main-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-8-0-prod-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-8-0-prod-compress.compress: "true"
       traefik.http.routers.myproject-odoo-8-0-prod-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-8-0-prod-main.middlewares: "myproject-odoo-8-0-prod-main-compress,myproject-odoo-8-0-prod-main-buffering"
+      traefik.http.routers.myproject-odoo-8-0-prod-main.middlewares:
+        myproject-odoo-8-0-prod-buffering, myproject-odoo-8-0-prod-compress
       traefik.http.routers.myproject-odoo-8-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
       traefik.http.routers.myproject-odoo-8-0-prod-main.service: "myproject-odoo-8-0-prod-main"
       traefik.http.routers.myproject-odoo-8-0-prod-main.tls: "true"
@@ -44,7 +45,9 @@ services:
       ? traefik.http.middlewares.myproject-odoo-8-0-prod-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-8-0-prod-forbidden-crawlers.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-8-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-8-0-prod-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-8-0-prod-forbidden-crawlers.middlewares:
+        myproject-odoo-8-0-prod-buffering, myproject-odoo-8-0-prod-compress,
+        myproject-odoo-8-0-prod-forbid-crawlers"
       traefik.http.routers.myproject-odoo-8-0-prod-forbidden-crawlers.rule:
         Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
         `/website/info/{anything:.*}`)

--- a/tests/default_settings/v8.0/test.yaml
+++ b/tests/default_settings/v8.0/test.yaml
@@ -28,20 +28,22 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
       # Forbid crawlers
       ? traefik.http.middlewares.myproject-odoo-8-0-test-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
-      : "noindex, nofollow"
+      : noindex, nofollow
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-8-0-test-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-8-0-test-main-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-8-0-test-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-8-0-test-compress.compress: "true"
       traefik.http.routers.myproject-odoo-8-0-test-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-8-0-test-main.middlewares: "myproject-odoo-8-0-test-main-compress,myproject-odoo-8-0-test-main-buffering,myproject-odoo-8-0-test-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-8-0-test-main.middlewares:
+        myproject-odoo-8-0-test-buffering, myproject-odoo-8-0-test-compress,
+        myproject-odoo-8-0-test-forbid-crawlers
       traefik.http.routers.myproject-odoo-8-0-test-main.rule: "host(`${DOMAIN_TEST}`)"
       traefik.http.routers.myproject-odoo-8-0-test-main.service: "myproject-odoo-8-0-test-main"
       traefik.http.routers.myproject-odoo-8-0-test-main.tls.certresolver: "letsencrypt"
       traefik.http.services.myproject-odoo-8-0-test-main.loadbalancer.server.port: 8069
       # Longpolling service
       traefik.http.routers.myproject-odoo-8-0-test-longpolling.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-8-0-test-longpolling.middlewares: "myproject-odoo-8-0-test-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-8-0-test-longpolling.middlewares: myproject-odoo-8-0-test-forbid-crawlers
       traefik.http.routers.myproject-odoo-8-0-test-longpolling.rule:
         "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
       traefik.http.routers.myproject-odoo-8-0-test-longpolling.service: "myproject-odoo-8-0-test-longpolling"
@@ -77,6 +79,18 @@ services:
       traefik.frontend.passHostHeader: "true"
       traefik.frontend.rule: "Host:${DOMAIN_TEST};PathPrefixStrip:/smtpfake/"
       traefik.port: "8025"
+      # Mailhog service
+      traefik.http.middlewares.myproject-odoo-8-0-test-mailhog-stripprefix.stripPrefix.prefixes: /smtpfake
+      traefik.http.routers.myproject-odoo-8-0-test-mailhog.entrypoints: web-main
+      traefik.http.routers.myproject-odoo-8-0-test-mailhog.middlewares:
+        myproject-odoo-8-0-test-buffering, myproject-odoo-8-0-test-compress,
+        myproject-odoo-8-0-test-forbid-crawlers,
+        myproject-odoo-8-0-test-mailhog-stripprefix
+      traefik.http.routers.myproject-odoo-8-0-test-mailhog.rule:
+        Host(`${DOMAIN_TEST}`) && PathPrefix(`/smtpfake/`)
+      traefik.http.routers.myproject-odoo-8-0-test-mailhog.service: myproject-odoo-8-0-test-mailhog
+      traefik.http.routers.myproject-odoo-8-0-test-mailhog.tls.certresolver: letsencrypt
+      traefik.http.services.myproject-odoo-8-0-test-mailhog.loadbalancer.server.port: 8025
     volumes:
       - "smtpconf:/etc/mailhog:ro,z"
     entrypoint: [sh, -c]

--- a/tests/default_settings/v9.0/prod.yaml
+++ b/tests/default_settings/v9.0/prod.yaml
@@ -45,11 +45,9 @@ services:
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-9-0-prod-forbidden-crawlers.entrypoints: "web-main"
       traefik.http.routers.myproject-odoo-9-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-9-0-prod-forbid-crawlers"
-      traefik.http.routers.myproject-odoo-9-0-prod-forbidden-crawlers.rule: |
-        Host(`${DOMAIN_PROD}`) && (
-          Path(`/web`, `/web/{anything:.*}`) ||
-          Path(`/website/info`, `/website/info/{anything:.*}`)
-        )
+      traefik.http.routers.myproject-odoo-9-0-prod-forbidden-crawlers.rule:
+        Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
+        `/website/info/{anything:.*}`)
       traefik.http.routers.myproject-odoo-9-0-prod-forbidden-crawlers.service: "myproject-odoo-9-0-prod-main"
       traefik.http.routers.myproject-odoo-9-0-prod-forbidden-crawlers.tls: "true"
       traefik.http.routers.myproject-odoo-9-0-prod-forbidden-crawlers.tls.certresolver: "letsencrypt"

--- a/tests/default_settings/v9.0/prod.yaml
+++ b/tests/default_settings/v9.0/prod.yaml
@@ -22,11 +22,12 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_PROD}"
       traefik.forbid-crawlers.frontend.rule: "Host:${DOMAIN_PROD};PathPrefix:/web,/web/{anything:.*},/website/info,/website/info/{anything:.*}"
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-9-0-prod-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-9-0-prod-main-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-9-0-prod-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-9-0-prod-compress.compress: "true"
       traefik.http.routers.myproject-odoo-9-0-prod-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-9-0-prod-main.middlewares: "myproject-odoo-9-0-prod-main-compress,myproject-odoo-9-0-prod-main-buffering"
+      traefik.http.routers.myproject-odoo-9-0-prod-main.middlewares:
+        myproject-odoo-9-0-prod-buffering, myproject-odoo-9-0-prod-compress
       traefik.http.routers.myproject-odoo-9-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
       traefik.http.routers.myproject-odoo-9-0-prod-main.service: "myproject-odoo-9-0-prod-main"
       traefik.http.routers.myproject-odoo-9-0-prod-main.tls: "true"
@@ -44,7 +45,9 @@ services:
       ? traefik.http.middlewares.myproject-odoo-9-0-prod-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-9-0-prod-forbidden-crawlers.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-9-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-9-0-prod-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-9-0-prod-forbidden-crawlers.middlewares:
+        myproject-odoo-9-0-prod-buffering, myproject-odoo-9-0-prod-compress,
+        myproject-odoo-9-0-prod-forbid-crawlers"
       traefik.http.routers.myproject-odoo-9-0-prod-forbidden-crawlers.rule:
         Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
         `/website/info/{anything:.*}`)

--- a/tests/default_settings/v9.0/test.yaml
+++ b/tests/default_settings/v9.0/test.yaml
@@ -28,20 +28,22 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
       # Forbid crawlers
       ? traefik.http.middlewares.myproject-odoo-9-0-test-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
-      : "noindex, nofollow"
+      : noindex, nofollow
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-9-0-test-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-9-0-test-main-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-9-0-test-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-9-0-test-compress.compress: "true"
       traefik.http.routers.myproject-odoo-9-0-test-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-9-0-test-main.middlewares: "myproject-odoo-9-0-test-main-compress,myproject-odoo-9-0-test-main-buffering,myproject-odoo-9-0-test-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-9-0-test-main.middlewares:
+        myproject-odoo-9-0-test-buffering, myproject-odoo-9-0-test-compress,
+        myproject-odoo-9-0-test-forbid-crawlers
       traefik.http.routers.myproject-odoo-9-0-test-main.rule: "host(`${DOMAIN_TEST}`)"
       traefik.http.routers.myproject-odoo-9-0-test-main.service: "myproject-odoo-9-0-test-main"
       traefik.http.routers.myproject-odoo-9-0-test-main.tls.certresolver: "letsencrypt"
       traefik.http.services.myproject-odoo-9-0-test-main.loadbalancer.server.port: 8069
       # Longpolling service
       traefik.http.routers.myproject-odoo-9-0-test-longpolling.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-9-0-test-longpolling.middlewares: "myproject-odoo-9-0-test-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-9-0-test-longpolling.middlewares: myproject-odoo-9-0-test-forbid-crawlers
       traefik.http.routers.myproject-odoo-9-0-test-longpolling.rule:
         "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
       traefik.http.routers.myproject-odoo-9-0-test-longpolling.service: "myproject-odoo-9-0-test-longpolling"
@@ -77,6 +79,18 @@ services:
       traefik.frontend.passHostHeader: "true"
       traefik.frontend.rule: "Host:${DOMAIN_TEST};PathPrefixStrip:/smtpfake/"
       traefik.port: "8025"
+      # Mailhog service
+      traefik.http.middlewares.myproject-odoo-9-0-test-mailhog-stripprefix.stripPrefix.prefixes: /smtpfake
+      traefik.http.routers.myproject-odoo-9-0-test-mailhog.entrypoints: web-main
+      traefik.http.routers.myproject-odoo-9-0-test-mailhog.middlewares:
+        myproject-odoo-9-0-test-buffering, myproject-odoo-9-0-test-compress,
+        myproject-odoo-9-0-test-forbid-crawlers,
+        myproject-odoo-9-0-test-mailhog-stripprefix
+      traefik.http.routers.myproject-odoo-9-0-test-mailhog.rule:
+        Host(`${DOMAIN_TEST}`) && PathPrefix(`/smtpfake/`)
+      traefik.http.routers.myproject-odoo-9-0-test-mailhog.service: myproject-odoo-9-0-test-mailhog
+      traefik.http.routers.myproject-odoo-9-0-test-mailhog.tls.certresolver: letsencrypt
+      traefik.http.services.myproject-odoo-9-0-test-mailhog.loadbalancer.server.port: 8025
     volumes:
       - "smtpconf:/etc/mailhog:ro,z"
     entrypoint: [sh, -c]

--- a/tests/samples/alt-domains/prod.yaml
+++ b/tests/samples/alt-domains/prod.yaml
@@ -34,11 +34,12 @@ services:
       traefik.alt-3.frontend.redirect.replacement: "$$1://${DOMAIN_PROD}/$$2"
       traefik.alt-3.frontend.rule: "Host:${DOMAIN_PROD_ALT_3}"
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-13-0-prod-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-13-0-prod-main-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-13-0-prod-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-13-0-prod-compress.compress: "true"
       traefik.http.routers.myproject-odoo-13-0-prod-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-13-0-prod-main.middlewares: "myproject-odoo-13-0-prod-main-compress,myproject-odoo-13-0-prod-main-buffering"
+      traefik.http.routers.myproject-odoo-13-0-prod-main.middlewares:
+        myproject-odoo-13-0-prod-buffering, myproject-odoo-13-0-prod-compress
       traefik.http.routers.myproject-odoo-13-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
       traefik.http.routers.myproject-odoo-13-0-prod-main.service: "myproject-odoo-13-0-prod-main"
       traefik.http.routers.myproject-odoo-13-0-prod-main.tls: "true"
@@ -48,7 +49,8 @@ services:
       traefik.http.middlewares.myproject-odoo-13-0-prod-redirect2main.redirectregex.regex: "^https://([^/]+)/(.*)$$"
       traefik.http.middlewares.myproject-odoo-13-0-prod-redirect2main.redirectregex.replacement: "https://${DOMAIN_PROD}/$${2}"
       traefik.http.routers.myproject-odoo-13-0-prod-altdomains.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-13-0-prod-altdomains.middlewares: "myproject-odoo-13-0-prod-redirect2main"
+      traefik.http.routers.myproject-odoo-13-0-prod-altdomains.middlewares:
+        myproject-odoo-13-0-prod-compress, myproject-odoo-13-0-prod-redirect2main
       traefik.http.routers.myproject-odoo-13-0-prod-altdomains.rule:
         Host(`${DOMAIN_PROD_ALT_0}`, `${DOMAIN_PROD_ALT_1}`, `${DOMAIN_PROD_ALT_2}`,
         `${DOMAIN_PROD_ALT_3}`)
@@ -67,7 +69,9 @@ services:
       ? traefik.http.middlewares.myproject-odoo-13-0-prod-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-13-0-prod-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.middlewares:
+        myproject-odoo-13-0-prod-buffering, myproject-odoo-13-0-prod-compress,
+        myproject-odoo-13-0-prod-forbid-crawlers"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.rule:
         Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
         `/website/info/{anything:.*}`)

--- a/tests/samples/alt-domains/prod.yaml
+++ b/tests/samples/alt-domains/prod.yaml
@@ -49,11 +49,9 @@ services:
       traefik.http.middlewares.myproject-odoo-13-0-prod-redirect2main.redirectregex.replacement: "https://${DOMAIN_PROD}/$${2}"
       traefik.http.routers.myproject-odoo-13-0-prod-altdomains.entrypoints: "web-main"
       traefik.http.routers.myproject-odoo-13-0-prod-altdomains.middlewares: "myproject-odoo-13-0-prod-redirect2main"
-      traefik.http.routers.myproject-odoo-13-0-prod-altdomains.rule: |
-        host(`${DOMAIN_PROD_ALT_0}`) ||
-        host(`${DOMAIN_PROD_ALT_1}`) ||
-        host(`${DOMAIN_PROD_ALT_2}`) ||
-        host(`${DOMAIN_PROD_ALT_3}`)
+      traefik.http.routers.myproject-odoo-13-0-prod-altdomains.rule:
+        Host(`${DOMAIN_PROD_ALT_0}`, `${DOMAIN_PROD_ALT_1}`, `${DOMAIN_PROD_ALT_2}`,
+        `${DOMAIN_PROD_ALT_3}`)
       traefik.http.routers.myproject-odoo-13-0-prod-altdomains.service: "myproject-odoo-13-0-prod-main"
       traefik.http.routers.myproject-odoo-13-0-prod-altdomains.tls: "true"
       traefik.http.routers.myproject-odoo-13-0-prod-altdomains.tls.certresolver: "letsencrypt"
@@ -70,11 +68,9 @@ services:
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.entrypoints: "web-main"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-13-0-prod-forbid-crawlers"
-      traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.rule: |
-        Host(`${DOMAIN_PROD}`) && (
-          Path(`/web`, `/web/{anything:.*}`) ||
-          Path(`/website/info`, `/website/info/{anything:.*}`)
-        )
+      traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.rule:
+        Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
+        `/website/info/{anything:.*}`)
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.service: "myproject-odoo-13-0-prod-main"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.tls: "true"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.tls.certresolver: "letsencrypt"

--- a/tests/samples/cidr-whitelist/prod.yaml
+++ b/tests/samples/cidr-whitelist/prod.yaml
@@ -22,13 +22,15 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_PROD}"
       traefik.forbid-crawlers.frontend.rule: "Host:${DOMAIN_PROD};PathPrefix:/web,/web/{anything:.*},/website/info,/website/info/{anything:.*}"
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-13-0-prod-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-13-0-prod-main-compress.compress: "true"
-      ? traefik.http.middlewares.myproject-odoo-13-0-prod-main-whitelist.IPWhiteList.sourceRange
+      ? traefik.http.middlewares.myproject-odoo-13-0-prod-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-13-0-prod-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-13-0-prod-whitelist.IPWhiteList.sourceRange
       : 123.123.123.123/24, 456.456.456.456
       traefik.http.routers.myproject-odoo-13-0-prod-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-13-0-prod-main.middlewares: "myproject-odoo-13-0-prod-main-compress,myproject-odoo-13-0-prod-main-buffering,myproject-odoo-13-0-prod-main-whitelist"
+      traefik.http.routers.myproject-odoo-13-0-prod-main.middlewares:
+        myproject-odoo-13-0-prod-buffering, myproject-odoo-13-0-prod-compress,
+        myproject-odoo-13-0-prod-whitelist
       traefik.http.routers.myproject-odoo-13-0-prod-main.rule: "host(`${DOMAIN_PROD}`)"
       traefik.http.routers.myproject-odoo-13-0-prod-main.service: "myproject-odoo-13-0-prod-main"
       traefik.http.routers.myproject-odoo-13-0-prod-main.tls: "true"
@@ -36,6 +38,7 @@ services:
       traefik.http.services.myproject-odoo-13-0-prod-main.loadbalancer.server.port: 8069
       # Longpolling service
       traefik.http.routers.myproject-odoo-13-0-prod-longpolling.entrypoints: "web-main"
+      traefik.http.routers.myproject-odoo-13-0-prod-longpolling.middlewares: myproject-odoo-13-0-prod-whitelist
       traefik.http.routers.myproject-odoo-13-0-prod-longpolling.rule:
         "host(`${DOMAIN_PROD}`) && pathprefix(`/longpolling/`)"
       traefik.http.routers.myproject-odoo-13-0-prod-longpolling.service: "myproject-odoo-13-0-prod-longpolling"
@@ -46,7 +49,9 @@ services:
       ? traefik.http.middlewares.myproject-odoo-13-0-prod-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-13-0-prod-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.middlewares:
+        myproject-odoo-13-0-prod-buffering, myproject-odoo-13-0-prod-compress,
+        myproject-odoo-13-0-prod-forbid-crawlers, myproject-odoo-13-0-prod-whitelist"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.rule:
         Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
         `/website/info/{anything:.*}`)

--- a/tests/samples/cidr-whitelist/prod.yaml
+++ b/tests/samples/cidr-whitelist/prod.yaml
@@ -47,11 +47,9 @@ services:
       : "noindex, nofollow"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.entrypoints: "web-main"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.middlewares: "myproject-odoo-13-0-prod-forbid-crawlers"
-      traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.rule: |
-        Host(`${DOMAIN_PROD}`) && (
-          Path(`/web`, `/web/{anything:.*}`) ||
-          Path(`/website/info`, `/website/info/{anything:.*}`)
-        )
+      traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.rule:
+        Host(`${DOMAIN_PROD}`) && Path(`/web`, `/web/{anything:.*}`, `/website/info`,
+        `/website/info/{anything:.*}`)
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.service: "myproject-odoo-13-0-prod-main"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.tls: "true"
       traefik.http.routers.myproject-odoo-13-0-prod-forbidden-crawlers.tls.certresolver: "letsencrypt"

--- a/tests/samples/cidr-whitelist/test.yaml
+++ b/tests/samples/cidr-whitelist/test.yaml
@@ -28,22 +28,25 @@ services:
       traefik.www.frontend.rule: "Host:${DOMAIN_TEST}"
       # Forbid crawlers
       ? traefik.http.middlewares.myproject-odoo-13-0-test-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
-      : "noindex, nofollow"
+      : noindex, nofollow
       # Main service
-      ? traefik.http.middlewares.myproject-odoo-13-0-test-main-buffering.buffering.retryExpression
-      : "IsNetworkError() && Attempts() < 5"
-      traefik.http.middlewares.myproject-odoo-13-0-test-main-compress.compress: "true"
-      ? traefik.http.middlewares.myproject-odoo-13-0-test-main-whitelist.IPWhiteList.sourceRange
+      ? traefik.http.middlewares.myproject-odoo-13-0-test-buffering.buffering.retryExpression
+      : IsNetworkError() && Attempts() < 5
+      traefik.http.middlewares.myproject-odoo-13-0-test-compress.compress: "true"
+      ? traefik.http.middlewares.myproject-odoo-13-0-test-whitelist.IPWhiteList.sourceRange
       : 123.123.123.123/24, 456.456.456.456
       traefik.http.routers.myproject-odoo-13-0-test-main.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-13-0-test-main.middlewares: "myproject-odoo-13-0-test-main-compress,myproject-odoo-13-0-test-main-buffering,myproject-odoo-13-0-test-forbid-crawlers,myproject-odoo-13-0-test-main-whitelist"
+      traefik.http.routers.myproject-odoo-13-0-test-main.middlewares:
+        myproject-odoo-13-0-test-buffering, myproject-odoo-13-0-test-compress,
+        myproject-odoo-13-0-test-forbid-crawlers, myproject-odoo-13-0-test-whitelist
       traefik.http.routers.myproject-odoo-13-0-test-main.rule: "host(`${DOMAIN_TEST}`)"
       traefik.http.routers.myproject-odoo-13-0-test-main.service: "myproject-odoo-13-0-test-main"
       traefik.http.routers.myproject-odoo-13-0-test-main.tls.certresolver: "letsencrypt"
       traefik.http.services.myproject-odoo-13-0-test-main.loadbalancer.server.port: 8069
       # Longpolling service
       traefik.http.routers.myproject-odoo-13-0-test-longpolling.entrypoints: "web-main"
-      traefik.http.routers.myproject-odoo-13-0-test-longpolling.middlewares: "myproject-odoo-13-0-test-forbid-crawlers"
+      traefik.http.routers.myproject-odoo-13-0-test-longpolling.middlewares:
+        myproject-odoo-13-0-test-forbid-crawlers, myproject-odoo-13-0-test-whitelist
       traefik.http.routers.myproject-odoo-13-0-test-longpolling.rule:
         "host(`${DOMAIN_TEST}`) && pathprefix(`/longpolling/`)"
       traefik.http.routers.myproject-odoo-13-0-test-longpolling.service: "myproject-odoo-13-0-test-longpolling"
@@ -79,6 +82,18 @@ services:
       traefik.frontend.passHostHeader: "true"
       traefik.frontend.rule: "Host:${DOMAIN_TEST};PathPrefixStrip:/smtpfake/"
       traefik.port: "8025"
+      # Mailhog service
+      traefik.http.middlewares.myproject-odoo-13-0-test-mailhog-stripprefix.stripPrefix.prefixes: /smtpfake
+      traefik.http.routers.myproject-odoo-13-0-test-mailhog.entrypoints: web-main
+      traefik.http.routers.myproject-odoo-13-0-test-mailhog.middlewares:
+        myproject-odoo-13-0-test-buffering, myproject-odoo-13-0-test-compress,
+        myproject-odoo-13-0-test-forbid-crawlers,
+        myproject-odoo-13-0-test-mailhog-stripprefix, myproject-odoo-13-0-test-whitelist
+      traefik.http.routers.myproject-odoo-13-0-test-mailhog.rule:
+        Host(`${DOMAIN_TEST}`) && PathPrefix(`/smtpfake/`)
+      traefik.http.routers.myproject-odoo-13-0-test-mailhog.service: myproject-odoo-13-0-test-mailhog
+      traefik.http.routers.myproject-odoo-13-0-test-mailhog.tls.certresolver: letsencrypt
+      traefik.http.services.myproject-odoo-13-0-test-mailhog.loadbalancer.server.port: 8025
     volumes:
       - "smtpconf:/etc/mailhog:ro,z"
     entrypoint: [sh, -c]

--- a/tests/test_default_settings.py
+++ b/tests/test_default_settings.py
@@ -5,7 +5,7 @@ import pytest
 import yaml
 from copier.main import copy
 from plumbum import local
-from plumbum.cmd import diff, git, invoke, pre_commit
+from plumbum.cmd import diff, git, invoke
 
 from .helpers import ALL_ODOO_VERSIONS, clone_self_dirty
 
@@ -28,11 +28,10 @@ def test_default_settings(tmp_path: Path, odoo_version: float):
             data={"odoo_version": odoo_version},
         )
     with local.cwd(dst):
-        # Pre-commit might be violated in these files and there's
-        # nothing we can do about it, so let's fix it here
-        pre_commit("run", "--files", ".copier-answers.yml", retcode=None)
-        # The result is a working git repo that respects pre-commit
+        # TODO When copier runs pre-commit before extracting diff, make sure
+        # here that it works as expected
         git("add", ".")
+        git("commit", "-am", "Hello World", retcode=1)  # pre-commit fails
         git("commit", "-am", "Hello World")
     # The result matches what we expect
     diff(

--- a/tests/test_nitpicking.py
+++ b/tests/test_nitpicking.py
@@ -124,7 +124,7 @@ def test_cidr_whitelist_rules(tmp_path: Path):
         data={"cidr_whitelist": ["123.123.123.123/24", "456.456.456.456"]},
     )
     with local.cwd(dst):
-        git("add", "prod.yaml")
+        git("add", "prod.yaml", "test.yaml")
         pre_commit("run", "-a", retcode=1)
     expected = Path("tests", "samples", "cidr-whitelist")
     assert (dst / "prod.yaml").read_text() == (expected / "prod.yaml").read_text()


### PR DESCRIPTION
That gives errors in Traefik 2 such as this:

```
ERRO[2020-04-03T13:46:39Z] error while parsing rule Host(`www.example.com`) && (
  Path(`/web`, `/web/{anything:.*}`) ||
  Path(`/website/info`, `/website/info/{anything:.*}`)
)
: 3:55: expected ')', found newline (and 1 more errors)  entryPointName=web-main routerName=example-odoo-12-0-prod-forbidden-crawlers@docker
```

@Tecnativa TT23300