### PR TITLE
Modernize transition

### DIFF
--- a/docs/scaffolding2copier.sh
+++ b/docs/scaffolding2copier.sh
@@ -12,7 +12,7 @@
 
 source .env
 copier $CUSTOM_COPIER_FLAGS \
-  -r "${TEMPLATE_VERSION-v1.0.1}" \
+  -r "${TEMPLATE_VERSION-v1.4.1}" \
   -d project_name="${PROJECT_NAME-$(basename $PWD)}" \
   -d project_license="${LICENSE-BSL-1.0}" \
   -d gitlab_url="${GITLAB_PREFIX-https://gitlab.com/example}/${PROJECT_NAME-$(basename $PWD)}" \

--- a/migrations.py
+++ b/migrations.py
@@ -15,3 +15,10 @@ def from_doodba_scaffolding_to_copier(c):
     Path(".travis.yml").unlink()
     Path(".vscode", "doodbasetup.py").unlink()
     Path("odoo", "custom", "src", "private", ".empty").unlink()
+    # When using Copier >= 3.0.5, this file didn't get properly migrated
+    editorconfig_file = Path(".editorconfig")
+    editorconfig_contents = editorconfig_file.read_text()
+    editorconfig_contents = editorconfig_contents.replace(
+        "[*.yml]", "[*.{code-snippets,code-workspace,json,md,yaml,yml}{,.jinja}]", 1
+    )
+    editorconfig_file.write_text(editorconfig_contents)


### PR DESCRIPTION
When using copier >= 3.0.5 (and you should use that), migrating from doodba-scaffolding skipped `.editorconfig` migration.

Instead of fixing it in doodba-scaffolding, which is today archived, I prefer to fix it here.

At the same time, the `scaffolding2copier` script gets the latest update.

@Tecnativa TT20357 TT20739 @chienandalu 