### PR TITLE
Warn about SMTP on port 465

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -272,6 +272,8 @@ smtp_relay_port:
   help: >-
     Indicate the port to connect in the SMTP server you just defined.
 
+    ⚠️ NEVER use port 465 👉 https://github.com/tomav/docker-mailserver/issues/1428
+
 smtp_relay_user:
   type: str
   help: >-


### PR DESCRIPTION
https://github.com/tomav/docker-mailserver/issues/1428 is a nasty problem that it's better to avoid if possible (and about 100% of the times it's possible).