### PR TITLE
Fix transition when missing files

### DIFF
--- a/docs/scaffolding2copier.sh
+++ b/docs/scaffolding2copier.sh
@@ -12,7 +12,7 @@
 
 source .env
 copier $CUSTOM_COPIER_FLAGS \
-  -r "${TEMPLATE_VERSION-v1.5.0}" \
+  -r "${TEMPLATE_VERSION-v1.5.1}" \
   -d project_name="${PROJECT_NAME-$(basename $PWD)}" \
   -d project_license="${LICENSE-BSL-1.0}" \
   -d gitlab_url="${GITLAB_PREFIX-https://gitlab.com/example}/${PROJECT_NAME-$(basename $PWD)}" \

--- a/migrations.py
+++ b/migrations.py
@@ -12,9 +12,16 @@ from invoke import task
 def from_doodba_scaffolding_to_copier(c):
     print("Removing remaining garbage from doodba-scaffolding.")
     shutil.rmtree(Path(".vscode", "doodba"), ignore_errors=True)
-    Path(".travis.yml").unlink()
-    Path(".vscode", "doodbasetup.py").unlink()
-    Path("odoo", "custom", "src", "private", ".empty").unlink()
+    garbage = (
+        Path(".travis.yml"),
+        Path(".vscode", "doodbasetup.py"),
+        Path("odoo", "custom", "src", "private", ".empty"),
+    )
+    for path in garbage:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
     # When using Copier >= 3.0.5, this file didn't get properly migrated
     editorconfig_file = Path(".editorconfig")
     editorconfig_contents = editorconfig_file.read_text()

--- a/tests/test_transition_to_copier.py
+++ b/tests/test_transition_to_copier.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from copier import copy
 from plumbum import local
-from plumbum.cmd import git
+from plumbum.cmd import git, invoke
 
 LATEST_VERSION_WITHOUT_COPIER = "v0.0.0"
 
@@ -75,3 +75,11 @@ def test_transtion_to_copier(
         assert not (
             tmp_path / "odoo" / "custom" / "src" / "private" / ".empty"
         ).exists()
+        # Ensure migrations are resilient to subproject changes
+        invoke(
+            "--search-root",
+            cloned_template,
+            "--collection",
+            "migrations",
+            "from-doodba-scaffolding-to-copier",
+        )


### PR DESCRIPTION
Without this patch, if any of these files was already removed, the migration would fail with `FileNotFoundError`.