### PR TITLE
Fix odoo/auto folder created with wrong permissions

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -45,6 +45,12 @@ _migrations:
         - --search-root={{ _copier_conf.src_path }}
         - --collection=migrations
         - from-doodba-scaffolding-to-copier
+  - version: v1.5.2
+    after:
+      - - invoke
+        - --search-root={{ _copier_conf.src_path }}
+        - --collection=migrations
+        - remove-odoo-auto-folder
 
 # Questions for the user
 project_author:

--- a/migrations.py
+++ b/migrations.py
@@ -29,3 +29,15 @@ def from_doodba_scaffolding_to_copier(c):
         "[*.yml]", "[*.{code-snippets,code-workspace,json,md,yaml,yml}{,.jinja}]", 1
     )
     editorconfig_file.write_text(editorconfig_contents)
+
+
+@task
+def remove_odoo_auto_folder(c):
+    """This folder makes no more sense for us.
+
+    The `invoke develop` task now handles its creation, which is done with
+    host user UID and GID to avoid problems.
+
+    There's no need to have it in our code tree anymore.
+    """
+    shutil.rmtree(Path("odoo", "auto"), ignore_errors=True)

--- a/tasks.py
+++ b/tasks.py
@@ -113,6 +113,7 @@ def update_test_samples(c):
                 dst = default_settings_path / f"v{v}"
                 c.run(f"poetry run copier -fr test -d odoo_version={v} copy . {dst}")
                 shutil.rmtree(dst / ".git")
+                shutil.rmtree(dst / "odoo" / "auto")
         finally:
             c.run("git tag --delete test")
         samples = Path("tests", "samples")

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -80,6 +80,7 @@ def develop(c):
                 c.run("python3 -m pip install --user pipx")
             c.run(f"pipx install {dep}")
     # Prepare environment
+    Path(PROJECT_ROOT, "odoo", "auto").mkdir(exist_ok=True)
     with c.cd(str(PROJECT_ROOT)):
         c.run("git init")
         c.run("ln -sf devel.yaml docker-compose.yml")

--- a/tests/default_settings/v10.0/tasks.py
+++ b/tests/default_settings/v10.0/tasks.py
@@ -81,6 +81,7 @@ def develop(c):
                 c.run("python3 -m pip install --user pipx")
             c.run(f"pipx install {dep}")
     # Prepare environment
+    Path(PROJECT_ROOT, "odoo", "auto").mkdir(exist_ok=True)
     with c.cd(str(PROJECT_ROOT)):
         c.run("git init")
         c.run("ln -sf devel.yaml docker-compose.yml")

--- a/tests/default_settings/v11.0/tasks.py
+++ b/tests/default_settings/v11.0/tasks.py
@@ -80,6 +80,7 @@ def develop(c):
                 c.run("python3 -m pip install --user pipx")
             c.run(f"pipx install {dep}")
     # Prepare environment
+    Path(PROJECT_ROOT, "odoo", "auto").mkdir(exist_ok=True)
     with c.cd(str(PROJECT_ROOT)):
         c.run("git init")
         c.run("ln -sf devel.yaml docker-compose.yml")

--- a/tests/default_settings/v12.0/tasks.py
+++ b/tests/default_settings/v12.0/tasks.py
@@ -80,6 +80,7 @@ def develop(c):
                 c.run("python3 -m pip install --user pipx")
             c.run(f"pipx install {dep}")
     # Prepare environment
+    Path(PROJECT_ROOT, "odoo", "auto").mkdir(exist_ok=True)
     with c.cd(str(PROJECT_ROOT)):
         c.run("git init")
         c.run("ln -sf devel.yaml docker-compose.yml")

--- a/tests/default_settings/v13.0/tasks.py
+++ b/tests/default_settings/v13.0/tasks.py
@@ -80,6 +80,7 @@ def develop(c):
                 c.run("python3 -m pip install --user pipx")
             c.run(f"pipx install {dep}")
     # Prepare environment
+    Path(PROJECT_ROOT, "odoo", "auto").mkdir(exist_ok=True)
     with c.cd(str(PROJECT_ROOT)):
         c.run("git init")
         c.run("ln -sf devel.yaml docker-compose.yml")

--- a/tests/default_settings/v7.0/tasks.py
+++ b/tests/default_settings/v7.0/tasks.py
@@ -81,6 +81,7 @@ def develop(c):
                 c.run("python3 -m pip install --user pipx")
             c.run(f"pipx install {dep}")
     # Prepare environment
+    Path(PROJECT_ROOT, "odoo", "auto").mkdir(exist_ok=True)
     with c.cd(str(PROJECT_ROOT)):
         c.run("git init")
         c.run("ln -sf devel.yaml docker-compose.yml")

--- a/tests/default_settings/v8.0/tasks.py
+++ b/tests/default_settings/v8.0/tasks.py
@@ -81,6 +81,7 @@ def develop(c):
                 c.run("python3 -m pip install --user pipx")
             c.run(f"pipx install {dep}")
     # Prepare environment
+    Path(PROJECT_ROOT, "odoo", "auto").mkdir(exist_ok=True)
     with c.cd(str(PROJECT_ROOT)):
         c.run("git init")
         c.run("ln -sf devel.yaml docker-compose.yml")

--- a/tests/default_settings/v9.0/tasks.py
+++ b/tests/default_settings/v9.0/tasks.py
@@ -81,6 +81,7 @@ def develop(c):
                 c.run("python3 -m pip install --user pipx")
             c.run(f"pipx install {dep}")
     # Prepare environment
+    Path(PROJECT_ROOT, "odoo", "auto").mkdir(exist_ok=True)
     with c.cd(str(PROJECT_ROOT)):
         c.run("git init")
         c.run("ln -sf devel.yaml docker-compose.yml")

--- a/tests/test_default_settings.py
+++ b/tests/test_default_settings.py
@@ -28,6 +28,7 @@ def test_default_settings(
     with local.cwd(dst):
         # TODO When copier runs pre-commit before extracting diff, make sure
         # here that it works as expected
+        Path(dst, "odoo", "auto").rmdir()
         git("add", ".")
         git("commit", "-am", "Hello World", retcode=1)  # pre-commit fails
         git("commit", "-am", "Hello World")


### PR DESCRIPTION
In doodba-copier-template, the `odoo/auto` folder is not provided just like it was with `doodba-scaffolding`.

When docker-compose needs it, docker it autogenerates it, and since docker >= root, the folder is owned by root. Then, the inner odoo process runs with lower permissions (same UID as host dev) and cannot symlink addons.

Here I fix #36 by creating `odoo/auto` with proper UID when executing `invoke develop`. There's also a new migration script that autoremoves that from the git tree if present, since that wasn't done before and a scaffolding might be coming from `doodba-scaffolding` where it was a present, git-tracked file.

However, for users that already had it created as root, the only workaround is to fix that folder's permissions or remove it manually as root. Sorry for that...