### PR TITLE
Change recommended XML extension for VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,7 @@
     "mrorz.language-gettext",
     "ms-azuretools.vscode-docker",
     "ms-python.python",
-    "qub.qub-xml-vscode",
+    "redhat.vscode-xml",
     "samuelcolvin.jinjahtml",
     "syler.sass-indented"
   ]

--- a/tests/default_settings/v10.0/.vscode/extensions.json
+++ b/tests/default_settings/v10.0/.vscode/extensions.json
@@ -7,7 +7,7 @@
     "mrorz.language-gettext",
     "ms-azuretools.vscode-docker",
     "ms-python.python",
-    "qub.qub-xml-vscode",
+    "redhat.vscode-xml",
     "samuelcolvin.jinjahtml",
     "syler.sass-indented"
   ]

--- a/tests/default_settings/v11.0/.vscode/extensions.json
+++ b/tests/default_settings/v11.0/.vscode/extensions.json
@@ -7,7 +7,7 @@
     "mrorz.language-gettext",
     "ms-azuretools.vscode-docker",
     "ms-python.python",
-    "qub.qub-xml-vscode",
+    "redhat.vscode-xml",
     "samuelcolvin.jinjahtml",
     "syler.sass-indented"
   ]

--- a/tests/default_settings/v12.0/.vscode/extensions.json
+++ b/tests/default_settings/v12.0/.vscode/extensions.json
@@ -7,7 +7,7 @@
     "mrorz.language-gettext",
     "ms-azuretools.vscode-docker",
     "ms-python.python",
-    "qub.qub-xml-vscode",
+    "redhat.vscode-xml",
     "samuelcolvin.jinjahtml",
     "syler.sass-indented"
   ]

--- a/tests/default_settings/v13.0/.vscode/extensions.json
+++ b/tests/default_settings/v13.0/.vscode/extensions.json
@@ -7,7 +7,7 @@
     "mrorz.language-gettext",
     "ms-azuretools.vscode-docker",
     "ms-python.python",
-    "qub.qub-xml-vscode",
+    "redhat.vscode-xml",
     "samuelcolvin.jinjahtml",
     "syler.sass-indented"
   ]

--- a/tests/default_settings/v7.0/.vscode/extensions.json
+++ b/tests/default_settings/v7.0/.vscode/extensions.json
@@ -7,7 +7,7 @@
     "mrorz.language-gettext",
     "ms-azuretools.vscode-docker",
     "ms-python.python",
-    "qub.qub-xml-vscode",
+    "redhat.vscode-xml",
     "samuelcolvin.jinjahtml",
     "syler.sass-indented"
   ]

--- a/tests/default_settings/v8.0/.vscode/extensions.json
+++ b/tests/default_settings/v8.0/.vscode/extensions.json
@@ -7,7 +7,7 @@
     "mrorz.language-gettext",
     "ms-azuretools.vscode-docker",
     "ms-python.python",
-    "qub.qub-xml-vscode",
+    "redhat.vscode-xml",
     "samuelcolvin.jinjahtml",
     "syler.sass-indented"
   ]

--- a/tests/default_settings/v9.0/.vscode/extensions.json
+++ b/tests/default_settings/v9.0/.vscode/extensions.json
@@ -7,7 +7,7 @@
     "mrorz.language-gettext",
     "ms-azuretools.vscode-docker",
     "ms-python.python",
-    "qub.qub-xml-vscode",
+    "redhat.vscode-xml",
     "samuelcolvin.jinjahtml",
     "syler.sass-indented"
   ]


### PR DESCRIPTION
The previous extension was buggy, causing random crashes in VSCode extensions host.

This one seems better, and is backed by Red Hat so it should have a brighter future. It provides similar benefits.