### PR TITLE
Support unvendored yaml module in tasks

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -11,7 +11,6 @@ from unittest import mock
 
 from invoke import task
 from invoke.util import yaml
-from invoke.vendor.yaml3.reader import Reader
 
 TEMPLATE_ROOT = Path(__file__).parent.resolve()
 ESSENTIALS = ("git", "python3", "poetry")
@@ -23,7 +22,7 @@ def _load_copier_conf():
         # HACK https://stackoverflow.com/a/44875714/1468388
         # TODO Remove hack when https://github.com/pyinvoke/invoke/issues/708 is fixed
         with mock.patch.object(
-            Reader,
+            yaml.Reader,
             "NON_PRINTABLE",
             re.compile(
                 "[^\x09\x0A\x0D\x20-\x7E\x85\xA0-"


### PR DESCRIPTION
If using a invoke package as supplied by your distro, and it happens that your distro removes vendored code (this happens with `dnf install invoke` in Fedora 32), tasks would fail.

This little change avoids that failure. Possibly the mock wouldn't be necessary, but it also doesn't harm.