### PR TITLE
Remove debug-statements in py2-only codebases

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -48,7 +48,9 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      {%- if odoo_version >= 11 %}
       - id: debug-statements
+      {%- endif %}
       - id: flake8
         name: flake8 except __init__.py
         exclude: /__init__\.py$

--- a/tasks.py
+++ b/tasks.py
@@ -22,7 +22,7 @@ def _load_copier_conf():
         # HACK https://stackoverflow.com/a/44875714/1468388
         # TODO Remove hack when https://github.com/pyinvoke/invoke/issues/708 is fixed
         with mock.patch.object(
-            yaml.Reader,
+            yaml.reader.Reader,
             "NON_PRINTABLE",
             re.compile(
                 "[^\x09\x0A\x0D\x20-\x7E\x85\xA0-"

--- a/tests/default_settings/v10.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v10.0/.pre-commit-config.yaml
@@ -45,7 +45,6 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: debug-statements
       - id: flake8
         name: flake8 except __init__.py
         exclude: /__init__\.py$

--- a/tests/default_settings/v7.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v7.0/.pre-commit-config.yaml
@@ -45,7 +45,6 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: debug-statements
       - id: flake8
         name: flake8 except __init__.py
         exclude: /__init__\.py$

--- a/tests/default_settings/v8.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v8.0/.pre-commit-config.yaml
@@ -45,7 +45,6 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: debug-statements
       - id: flake8
         name: flake8 except __init__.py
         exclude: /__init__\.py$

--- a/tests/default_settings/v9.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v9.0/.pre-commit-config.yaml
@@ -45,7 +45,6 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: debug-statements
       - id: flake8
         name: flake8 except __init__.py
         exclude: /__init__\.py$


### PR DESCRIPTION
This check will possibly fail with syntax errors in py2 code, and has no utility there. Remove it.

Also add test about specific pre-commit stuff, to be able to remove scaffoldign samples in the future.