### PR TITLE
Add some custom downstream tasks

### DIFF
--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -183,3 +183,28 @@ def logs(c, tail=10):
         cmd += f" --tail {tail}"
     with c.cd(str(PROJECT_ROOT)):
         c.run(cmd)
+
+
+@task(develop)
+def psql(c, db=None):
+    """Get a psql"""
+    cmd = "docker-compose run --rm odoo psql"
+    if db:
+        cmd += f" {db}"
+    c.run(cmd)
+
+
+@task(develop)
+def shell(c, db=None):
+    """Get an Odoo shell"""
+    cmd = "docker-compose run --rm odoo odoo shell"
+    if db:
+        cmd += f" -d {db}"
+    c.run(cmd)
+
+
+@task(develop)
+def scaffold(c, name):
+    """Create a scaffold"""
+    cmd = f"docker-compose run --rm odoo odoo scaffold {name} /opt/odoo/custom/src/private"
+    c.run(cmd)


### PR DESCRIPTION
This PR adds some additional downstream tasks to the copier template that we've found quite useful when migrating from other projects.

The scaffold task also requires a further modification to `devel.yaml.jinja` to make `./odoo/custom` volume non-readonly. I'm not sure if there's a reason for it to be kept readonly, so I've left it out for now, and I'm willing to update/fix the PR if it's helpful.