### PR TITLE
Avoid writing python bytecode in devel

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -51,15 +51,6 @@ repos:
       {%- if odoo_version >= 11 %}
       - id: debug-statements
       {%- endif %}
-      - id: flake8
-        name: flake8 except __init__.py
-        exclude: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
-      - id: flake8
-        name: flake8 only __init__.py
-        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
-        files: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
       - id: fix-encoding-pragma
         {%- if odoo_version >= 11 %}
         args: ["--remove"]
@@ -72,6 +63,18 @@ repos:
       - id: check-xml
       - id: mixed-line-ending
         args: ["--fix=lf"]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        name: flake8 except __init__.py
+        exclude: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
+      - id: flake8
+        name: flake8 only __init__.py
+        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
+        files: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v2.3.1
     hooks:

--- a/devel.yaml.jinja
+++ b/devel.yaml.jinja
@@ -32,6 +32,7 @@ services:
       LIST_DB: "true"
       PTVSD_ENABLE: "${DOODBA_PTVSD_ENABLE:-0}"
       PGDATABASE: &dbname devel
+      PYTHONDONTWRITEBYTECODE: 1
       PYTHONOPTIMIZE: ""
       PYTHONPATH: /opt/odoo/custom/src/odoo
       SMTP_PORT: "1025"

--- a/tests/default_settings/v10.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v10.0/.pre-commit-config.yaml
@@ -45,15 +45,6 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: flake8
-        name: flake8 except __init__.py
-        exclude: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
-      - id: flake8
-        name: flake8 only __init__.py
-        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
-        files: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
       - id: fix-encoding-pragma
       - id: check-case-conflict
       - id: check-docstring-first
@@ -63,6 +54,18 @@ repos:
       - id: check-xml
       - id: mixed-line-ending
         args: ["--fix=lf"]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        name: flake8 except __init__.py
+        exclude: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
+      - id: flake8
+        name: flake8 only __init__.py
+        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
+        files: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v2.3.1
     hooks:

--- a/tests/default_settings/v10.0/devel.yaml
+++ b/tests/default_settings/v10.0/devel.yaml
@@ -32,6 +32,7 @@ services:
       LIST_DB: "true"
       PTVSD_ENABLE: "${DOODBA_PTVSD_ENABLE:-0}"
       PGDATABASE: &dbname devel
+      PYTHONDONTWRITEBYTECODE: 1
       PYTHONOPTIMIZE: ""
       PYTHONPATH: /opt/odoo/custom/src/odoo
       SMTP_PORT: "1025"

--- a/tests/default_settings/v11.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v11.0/.pre-commit-config.yaml
@@ -46,15 +46,6 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: debug-statements
-      - id: flake8
-        name: flake8 except __init__.py
-        exclude: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
-      - id: flake8
-        name: flake8 only __init__.py
-        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
-        files: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
       - id: fix-encoding-pragma
         args: ["--remove"]
       - id: check-case-conflict
@@ -65,6 +56,18 @@ repos:
       - id: check-xml
       - id: mixed-line-ending
         args: ["--fix=lf"]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        name: flake8 except __init__.py
+        exclude: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
+      - id: flake8
+        name: flake8 only __init__.py
+        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
+        files: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v2.3.1
     hooks:

--- a/tests/default_settings/v11.0/devel.yaml
+++ b/tests/default_settings/v11.0/devel.yaml
@@ -32,6 +32,7 @@ services:
       LIST_DB: "true"
       PTVSD_ENABLE: "${DOODBA_PTVSD_ENABLE:-0}"
       PGDATABASE: &dbname devel
+      PYTHONDONTWRITEBYTECODE: 1
       PYTHONOPTIMIZE: ""
       PYTHONPATH: /opt/odoo/custom/src/odoo
       SMTP_PORT: "1025"

--- a/tests/default_settings/v12.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v12.0/.pre-commit-config.yaml
@@ -46,15 +46,6 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: debug-statements
-      - id: flake8
-        name: flake8 except __init__.py
-        exclude: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
-      - id: flake8
-        name: flake8 only __init__.py
-        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
-        files: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
       - id: fix-encoding-pragma
         args: ["--remove"]
       - id: check-case-conflict
@@ -65,6 +56,18 @@ repos:
       - id: check-xml
       - id: mixed-line-ending
         args: ["--fix=lf"]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        name: flake8 except __init__.py
+        exclude: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
+      - id: flake8
+        name: flake8 only __init__.py
+        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
+        files: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v2.3.1
     hooks:

--- a/tests/default_settings/v12.0/devel.yaml
+++ b/tests/default_settings/v12.0/devel.yaml
@@ -32,6 +32,7 @@ services:
       LIST_DB: "true"
       PTVSD_ENABLE: "${DOODBA_PTVSD_ENABLE:-0}"
       PGDATABASE: &dbname devel
+      PYTHONDONTWRITEBYTECODE: 1
       PYTHONOPTIMIZE: ""
       PYTHONPATH: /opt/odoo/custom/src/odoo
       SMTP_PORT: "1025"

--- a/tests/default_settings/v13.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v13.0/.pre-commit-config.yaml
@@ -46,15 +46,6 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: debug-statements
-      - id: flake8
-        name: flake8 except __init__.py
-        exclude: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
-      - id: flake8
-        name: flake8 only __init__.py
-        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
-        files: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
       - id: fix-encoding-pragma
         args: ["--remove"]
       - id: check-case-conflict
@@ -65,6 +56,18 @@ repos:
       - id: check-xml
       - id: mixed-line-ending
         args: ["--fix=lf"]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        name: flake8 except __init__.py
+        exclude: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
+      - id: flake8
+        name: flake8 only __init__.py
+        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
+        files: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v2.3.1
     hooks:

--- a/tests/default_settings/v13.0/devel.yaml
+++ b/tests/default_settings/v13.0/devel.yaml
@@ -32,6 +32,7 @@ services:
       LIST_DB: "true"
       PTVSD_ENABLE: "${DOODBA_PTVSD_ENABLE:-0}"
       PGDATABASE: &dbname devel
+      PYTHONDONTWRITEBYTECODE: 1
       PYTHONOPTIMIZE: ""
       PYTHONPATH: /opt/odoo/custom/src/odoo
       SMTP_PORT: "1025"

--- a/tests/default_settings/v7.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v7.0/.pre-commit-config.yaml
@@ -45,15 +45,6 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: flake8
-        name: flake8 except __init__.py
-        exclude: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
-      - id: flake8
-        name: flake8 only __init__.py
-        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
-        files: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
       - id: fix-encoding-pragma
       - id: check-case-conflict
       - id: check-docstring-first
@@ -63,6 +54,18 @@ repos:
       - id: check-xml
       - id: mixed-line-ending
         args: ["--fix=lf"]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        name: flake8 except __init__.py
+        exclude: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
+      - id: flake8
+        name: flake8 only __init__.py
+        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
+        files: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v2.3.1
     hooks:

--- a/tests/default_settings/v7.0/devel.yaml
+++ b/tests/default_settings/v7.0/devel.yaml
@@ -32,6 +32,7 @@ services:
       LIST_DB: "true"
       PTVSD_ENABLE: "${DOODBA_PTVSD_ENABLE:-0}"
       PGDATABASE: &dbname devel
+      PYTHONDONTWRITEBYTECODE: 1
       PYTHONOPTIMIZE: ""
       PYTHONPATH: /opt/odoo/custom/src/odoo
       SMTP_PORT: "1025"

--- a/tests/default_settings/v8.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v8.0/.pre-commit-config.yaml
@@ -45,15 +45,6 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: flake8
-        name: flake8 except __init__.py
-        exclude: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
-      - id: flake8
-        name: flake8 only __init__.py
-        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
-        files: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
       - id: fix-encoding-pragma
       - id: check-case-conflict
       - id: check-docstring-first
@@ -63,6 +54,18 @@ repos:
       - id: check-xml
       - id: mixed-line-ending
         args: ["--fix=lf"]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        name: flake8 except __init__.py
+        exclude: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
+      - id: flake8
+        name: flake8 only __init__.py
+        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
+        files: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v2.3.1
     hooks:

--- a/tests/default_settings/v8.0/devel.yaml
+++ b/tests/default_settings/v8.0/devel.yaml
@@ -32,6 +32,7 @@ services:
       LIST_DB: "true"
       PTVSD_ENABLE: "${DOODBA_PTVSD_ENABLE:-0}"
       PGDATABASE: &dbname devel
+      PYTHONDONTWRITEBYTECODE: 1
       PYTHONOPTIMIZE: ""
       PYTHONPATH: /opt/odoo/custom/src/odoo
       SMTP_PORT: "1025"

--- a/tests/default_settings/v9.0/.pre-commit-config.yaml
+++ b/tests/default_settings/v9.0/.pre-commit-config.yaml
@@ -45,15 +45,6 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: flake8
-        name: flake8 except __init__.py
-        exclude: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
-      - id: flake8
-        name: flake8 only __init__.py
-        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
-        files: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
       - id: fix-encoding-pragma
       - id: check-case-conflict
       - id: check-docstring-first
@@ -63,6 +54,18 @@ repos:
       - id: check-xml
       - id: mixed-line-ending
         args: ["--fix=lf"]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        name: flake8 except __init__.py
+        exclude: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
+      - id: flake8
+        name: flake8 only __init__.py
+        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
+        files: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==19.8.0"]
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v2.3.1
     hooks:

--- a/tests/default_settings/v9.0/devel.yaml
+++ b/tests/default_settings/v9.0/devel.yaml
@@ -32,6 +32,7 @@ services:
       LIST_DB: "true"
       PTVSD_ENABLE: "${DOODBA_PTVSD_ENABLE:-0}"
       PGDATABASE: &dbname devel
+      PYTHONDONTWRITEBYTECODE: 1
       PYTHONOPTIMIZE: ""
       PYTHONPATH: /opt/odoo/custom/src/odoo
       SMTP_PORT: "1025"

--- a/tests/test_nitpicking.py
+++ b/tests/test_nitpicking.py
@@ -208,3 +208,17 @@ def test_pre_commit_config(
                 ]
                 assert {"id": "fix-encoding-pragma"} in repo["hooks"]
     assert found == should_find
+
+
+def test_no_python_write_bytecode_in_devel(
+    tmp_path: Path, cloned_template: Path, supported_odoo_version: float
+):
+    copy(
+        str(cloned_template),
+        str(tmp_path),
+        vcs_ref="HEAD",
+        force=True,
+        data={"odoo_version": supported_odoo_version},
+    )
+    devel = yaml.load((tmp_path / "devel.yaml").read_text())
+    assert devel["services"]["odoo"]["environment"]["PYTHONDONTWRITEBYTECODE"] == 1


### PR DESCRIPTION
For some reason, this was working before with no problem, although all code was mounted in readonly mode to avoid some root user inside your container writing files in your host system that your user wouldn't have permissions to later delete.

But after merging https://github.com/Tecnativa/doodba/pull/311, sometimes odoo fails when autoreloading because it tries to write `*.pyc` files where it can't.

This should fix it. BTW I update MQT code.