### PR TITLE
Do not format on save XML files

### DIFF
--- a/.vscode/settings.json.jinja
+++ b/.vscode/settings.json.jinja
@@ -30,5 +30,8 @@
   },
   "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[xml]": {
+    "editor.formatOnSave": false
   }
 }


### PR DESCRIPTION
VSCode's XML formatter conflicts with prettier, and is actually buggy. Also VSCode prettier extension doesn't include the XML prettier plugin.

So, it's better to disable it and leave pre-commit do its stuff.