### PR TITLE
Mount all /opt/auto in devel

### DIFF
--- a/devel.yaml.jinja
+++ b/devel.yaml.jinja
@@ -43,7 +43,7 @@ services:
       WITHOUT_DEMO: "${DOODBA_WITHOUT_DEMO-false}"
     volumes:
       - ./odoo/custom:/opt/odoo/custom:ro,z
-      - ./odoo/auto/addons:/opt/odoo/auto/addons:rw,z
+      - ./odoo/auto:/opt/odoo/auto:rw,z
     depends_on:
       - cdnjs_cloudflare_proxy
       - db

--- a/docs/daily-usage.md
+++ b/docs/daily-usage.md
@@ -532,7 +532,3 @@ adding the whitelist proxy like this to your docker-compose.yml:
 [development]: #development
 [testing]: #testing
 [production]: #production
-
-```
-
-```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,6 +18,8 @@ Maybe not so frequent, but interesting anyway. 🤷
 - [How to get proper assets when printing reports?](#how-to-get-proper-assets-when-printing-reports)
 - [How to have good QA and test in my CI with Doodba?](#how-to-have-good-qa-and-test-in-my-ci-with-doodba)
 - [This project is too opinionated, but can I question any of those opinions?](#this-project-is-too-opinionated-but-can-i-question-any-of-those-opinions)
+- [Where are screencasts and screenshots of my failed E2E tests?](#where-are-screencasts-and-screenshots-of-my-failed-e2e-tests)
+  - [How to get screencasts and screenshots of failed E2E tests in Odoo 12.0?](#how-to-get-screencasts-and-screenshots-of-failed-e2e-tests-in-odoo-120)
 - [Why pre-commit fails each time I copy or update the template?](#why-pre-commit-fails-each-time-i-copy-or-update-the-template)
 - [Why XML is broken after running pre-commit?](#why-xml-is-broken-after-running-pre-commit)
 - [Why is Odoo saying that its database is not initialized?](#why-is-odoo-saying-that-its-database-is-not-initialized)
@@ -304,6 +306,43 @@ Go there to get more instructions.
 ## This project is too opinionated, but can I question any of those opinions?
 
 Of course. There's no guarantee that we will like it, but please do it. 😉
+
+## Where are screencasts and screenshots of my failed E2E tests?
+
+Starting with Odoo (and Doodba) 13.0, when you're in [the devel
+environment][development] and run some E2E test (tours, JS tests...) that fails, Odoo
+will output screenshots and screencasts automatically. These are very useful for
+debugging.
+
+You can find them in the `./odoo/auto/test-artifacts` directory in your development
+host. No need to sniff around inside the container to find them.
+
+### How to get screencasts and screenshots of failed E2E tests in Odoo 12.0?
+
+In Odoo (and Doodba) 12.0, the screencasts and screenshots feature is also supported,
+but it is less intuitive: just apply this patch to your `devel.yaml` file:
+
+```diff
+diff --git a/devel.yaml b/devel.yaml
+index 2026e7c..d4e5a68 100644
+--- a/devel.yaml
++++ b/devel.yaml
+@@ -60,6 +60,7 @@ services:
+       - --limit-time-real=9999999
+       - --workers=0
+       - --dev=reload,qweb,werkzeug,xml
++      - --logfile=/opt/auto/test-artifacts/odoo.log
+
+   db:
+     extends:
+```
+
+You'll find Odoo logs in `./odoo/auto/test-artifacts/odoo.log` file, and screencasts and
+screenshots will be around with some weird names. As a side effect, your container will
+output no logs to the console.
+
+Since this is an awkward side effect of that setting, we're not shipping that by
+default.
 
 ## Why pre-commit fails each time I copy or update the template?
 


### PR DESCRIPTION
Mounting only the `addons` subfolder made sense in old times when we had to fight with UIDs and all that 💩.

We can now mount the whole `auto` folder to have more room of communication from the container to the development host. This will make JS test development much easier once https://github.com/Tecnativa/doodba/pull/316 lands.