### PR TITLE
README: add dependencies to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This project lets you maintain [Odoo][] deployments based on [Doodba][] using
 This project itself is just the template, but you need to install these tools to use it:
 
 - [copier][] v3.0.6 or newer
+- [docker-compose](https://docs.docker.com/compose/install/)
 - [git](https://git-scm.com/) 2.24 or newer
 - [invoke](https://www.pyinvoke.org/) installed in Python 3.6+ (and the binary must be
   called `invoke` — beware if your distro installs it as `invoke3` or similar).

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This project itself is just the template, but you need to install these tools to
   called `invoke` — beware if your distro installs it as `invoke3` or similar).
 - [pre-commit](https://pre-commit.com/)
 - [python](https://www.python.org/) 3.6+
+- [venv](https://docs.python.org/3/library/venv.html)
 
 Install non-python apps with your distro's recommended package manager. The recommended
 way to install Python CLI apps is [pipx](https://pipxproject.github.io/pipx/):

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ way to install Python CLI apps is [pipx](https://pipxproject.github.io/pipx/):
 
 ```bash
 python3 -m pip install --user pipx
+pipx install docker-compose
 pipx install copier
 pipx install invoke
 pipx install pre-commit

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -13,11 +13,6 @@ from invoke import task
 
 PROJECT_ROOT = Path(__file__).parent.absolute()
 SRC_PATH = PROJECT_ROOT / "odoo" / "custom" / "src"
-DEVELOP_DEPENDENCIES = (
-    "copier",
-    "docker-compose",
-    "pre-commit",
-)
 UID_ENV = {"GID": str(os.getgid()), "UID": str(os.getuid()), "UMASK": "27"}
 
 
@@ -72,16 +67,6 @@ def write_code_workspace_file(c, cw_path=None):
 @task
 def develop(c):
     """Set up a basic development environment."""
-    # Install basic dependencies
-    for dep in DEVELOP_DEPENDENCIES:
-        try:
-            c.run(f"{dep} --version", hide=True)
-        except Exception:
-            try:
-                c.run("pipx --version")
-            except Exception:
-                c.run("python3 -m pip install --user pipx")
-            c.run(f"pipx install {dep}")
     # Prepare environment
     Path(PROJECT_ROOT, "odoo", "auto", "addons").mkdir(parents=True, exist_ok=True)
     with c.cd(str(PROJECT_ROOT)):


### PR DESCRIPTION
Without having pipx installed, you will get an error after answering copier questions:

    /bin/bash: pipx: command not found

I know about the code that tries to install pipx:

https://github.com/Tecnativa/doodba-copier-template/blob/1b018201c3fad9da43a615cad481a3a217d29f48/tasks_downstream.py#L83

But it doesn't work if you call copier without sudo
```

 > Running task 1 of 1: invoke develop
/bin/bash: pipx: command not found
Collecting pipx
  Downloading https://files.pythonhosted.org/packages/b7/63/f8a8119ff7abd5833c41ec0d7c0d46502462aab9a7bb649502723127289a/pipx-0.15.4.0-py3-none-any.whl
Collecting userpath (from pipx)
  Downloading https://files.pythonhosted.org/packages/d8/1e/bad15e27cf1190f24d837205aaddfe855ef920bb6ab162e3df3506c51e94/userpath-1.4.0-py2.py3-none-any.whl
Collecting argcomplete<2.0,>=1.9.4 (from pipx)
  Downloading https://files.pythonhosted.org/packages/82/7d/455e149c28c320044cb763c23af375bd77d52baca041f611f5c2b4865cf4/argcomplete-1.11.1-py2.py3-none-any.whl
Collecting distro; platform_system == "Linux" (from userpath->pipx)
  Downloading https://files.pythonhosted.org/packages/25/b7/b3c4270a11414cb22c6352ebc7a83aaa3712043be29daa05018fd5a5c956/distro-1.5.0-py2.py3-none-any.whl
Collecting click (from userpath->pipx)
  Downloading https://files.pythonhosted.org/packages/d2/3d/fa76db83bf75c4f8d338c2fd15c8d33fdd7ad23a9b5e57eb6c5de26b430e/click-7.1.2-py2.py3-none-any.whl (82kB)
Collecting importlib-metadata<2,>=0.23; python_version == "3.6" (from argcomplete<2.0,>=1.9.4->pipx)
  Downloading https://files.pythonhosted.org/packages/98/13/a1d703ec396ade42c1d33df0e1cb691a28b7c08b336a5683912c87e04cd7/importlib_metadata-1.6.1-py2.py3-none-any.whl
Collecting zipp>=0.5 (from importlib-metadata<2,>=0.23; python_version == "3.6"->argcomplete<2.0,>=1.9.4->pipx)
  Downloading https://files.pythonhosted.org/packages/b2/34/bfcb43cc0ba81f527bc4f40ef41ba2ff4080e047acb0586b56b3d017ace4/zipp-3.1.0-py3-none-any.whl
Installing collected packages: distro, click, userpath, zipp, importlib-metadata, argcomplete, pipx
Successfully installed argcomplete-1.11.1 click-7.1.2 distro-1.5.0 importlib-metadata-1.6.1 pipx-0.15.4.0 userpath-1.4.0 zipp-3.1.0
/bin/bash: pipx: command not found
Something went wrong. Removing destination folder.
Traceback (most recent call last):
  File "/usr/local/bin/copier", line 11, in <module>
    sys.exit(CopierApp.run())
  File "/usr/local/lib/python3.6/dist-packages/plumbum/cli/application.py", line 577, in run
    inst, retcode = subapp.run(argv, exit=False)
  File "/usr/local/lib/python3.6/dist-packages/plumbum/cli/application.py", line 572, in run
    retcode = inst.main(*tailargs)
  File "/usr/local/lib/python3.6/dist-packages/copier/cli.py", line 17, in _wrapper
    return method(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/copier/cli.py", line 158, in main
    self.parent._copy(template_src, destination_path)
  File "/usr/local/lib/python3.6/dist-packages/copier/cli.py", line 121, in _copy
    **kwargs,
  File "/usr/local/lib/python3.6/dist-packages/copier/main.py", line 142, in copy
    copy_local(conf=conf)
  File "/usr/local/lib/python3.6/dist-packages/copier/main.py", line 196, in copy_local
    conf, render, [{"task": t, "extra_env": {"STAGE": "task"}} for t in conf.tasks]
  File "/usr/local/lib/python3.6/dist-packages/copier/main.py", line 369, in run_tasks
    subprocess.run(task_cmd, shell=use_shell, check=True, env=local.env)
  File "/usr/lib/python3.6/subprocess.py", line 438, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command 'invoke develop' returned non-zero exit status 127.



```