### PR TITLE
Suggest boto3+s3:// backups by default

### DIFF
--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -76,7 +76,7 @@ services:
   {%- if backup_dst %}
 
   backup:
-    image: tecnativa/duplicity:postgres{% if backup_dst.startswith('s3://') %}-s3{% endif %}
+    image: tecnativa/duplicity:postgres{% if backup_dst.startswith(('boto3+s3://', 's3://', 's3+http://')) %}-s3{% endif %}
     hostname: backup
     domainname: "$DOMAIN_PROD"
     init: true

--- a/copier.yml
+++ b/copier.yml
@@ -329,7 +329,7 @@ backup_dst:
   type: str
   help: >-
     If you want to use an Amazon S3 bucket, write its URL like
-    `s3://s3.amazonaws.com/example-bucket/example/path` to make sure it works fine.
+    `boto3+s3://example_bucket[/example/path]` to make sure it works fine.
 
     If you want to use any other backend, supply any URL supported by Duplicity (our
     choice backup engine; read http://duplicity.nongnu.org/vers8/duplicity.1.html#sect7

--- a/docs/scaffolding2copier.sh
+++ b/docs/scaffolding2copier.sh
@@ -33,7 +33,7 @@ copier $CUSTOM_COPIER_FLAGS \
   -d smtp_relay_user="$SMTP_REAL_RELAY_USER" \
   -d smtp_canonical_default="$SMTP_REAL_NON_CANONICAL_DEFAULT" \
   -d smtp_canonical_domains="[$SMTP_REAL_CANONICAL_DOMAINS]" \
-  -d backup_dst="s3://s3.amazonaws.com/$BACKUP_S3_BUCKET" \
+  -d backup_dst="boto3+s3://$BACKUP_S3_BUCKET" \
   -d backup_email_from="$BACKUP_EMAIL_FROM" \
   -d backup_email_to="$BACKUP_EMAIL_TO" \
   -d backup_deletion=false \

--- a/tests/test_settings_effect.py
+++ b/tests/test_settings_effect.py
@@ -63,7 +63,10 @@ def test_prod_alt_domains(
 
 
 @pytest.mark.parametrize("backup_deletion", (False, True))
-@pytest.mark.parametrize("backup_dst", (None, "s3://example", "sftp://example"))
+@pytest.mark.parametrize(
+    "backup_dst",
+    (None, "s3://example", "s3+http://example", "boto3+s3://example", "sftp://example"),
+)
 @pytest.mark.parametrize("smtp_relay_host", (None, "example"))
 def test_backup_config(
     backup_deletion: bool,
@@ -97,7 +100,7 @@ def test_backup_config(
         assert "backup" not in prod["services"]
         return
     # Check selected duplicity image
-    if backup_dst == "s3://example":
+    if "s3" in backup_dst:
         assert prod["services"]["backup"]["image"] == "tecnativa/duplicity:postgres-s3"
     else:
         assert prod["services"]["backup"]["image"] == "tecnativa/duplicity:postgres"


### PR DESCRIPTION
Following https://github.com/Tecnativa/docker-duplicity/pull/35, suggest using boto3 backend by default, which is expected to work more reliably from now on. The URL shape differs, though.