### PR TITLE
Update wdb stop signal hack

### DIFF
--- a/devel.yaml.jinja
+++ b/devel.yaml.jinja
@@ -87,7 +87,7 @@ services:
     ports:
       - "127.0.0.1:1984:1984"
     # HACK https://github.com/Kozea/wdb/issues/136
-    stop_signal: KILL
+    init: true
 
   # Whitelist outgoing traffic for tests, reports, etc.
   cdnjs_cloudflare_proxy:


### PR DESCRIPTION
Previous hack made it quick to stop the `wdb.server.py` process, which doesn't react properly to `SIGTERM` as explained in https://github.com/Kozea/wdb/issues/136.

However, if this process was still alive, when powering off the computer it took forever to kill it. Thus, using this alternative hack is better, because it uses docker's built-in `tini` to reap child processes. It is still fast, but it also helps the host's process reaper to work reliably.

BTW I update MQT submodule.