### PR TITLE
Include pgweb in the default devel toolbelt

### DIFF
--- a/devel.yaml.jinja
+++ b/devel.yaml.jinja
@@ -73,6 +73,16 @@ services:
       POSTGRES_DB: *dbname
       POSTGRES_PASSWORD: odoopassword
 
+  pgweb:
+    image: sosedoff/pgweb
+    networks: *public
+    ports:
+      - "127.0.0.1:8081:8081"
+    environment:
+      DATABASE_URL: postgres://$DB_USER:odoopassword@db:5432/devel?sslmode=disable
+    depends_on:
+      - db
+
   smtp:
     extends:
       file: common.yaml

--- a/docs/daily-usage.md
+++ b/docs/daily-usage.md
@@ -15,6 +15,7 @@ it now? You'll learn that here.
     - [MailHog](#mailhog)
     - [Network isolation](#network-isolation)
     - [wdb](#wdb)
+    - [pgweb](#pgweb)
   - [Production](#production)
     - [Prebuilding images](#prebuilding-images)
     - [Adding secrets](#adding-secrets)
@@ -163,6 +164,14 @@ It's available by default on the [development][] environment, where you can brow
 http://localhost:1984 to use it.
 
 **⚠️ DO NOT USE IT IN PRODUCTION ENVIRONMENTS ⚠️** (I had to say it).
+
+#### pgweb
+
+[Pgweb](http://sosedoff.github.io/pgweb/) is a small, beautiful and quick tool to
+inspect a Postgres database.
+
+We ship it preconfigured in the [development][] environment. Just start it and open
+http://localhost:8081 to use it.
 
 ### Production
 


### PR DESCRIPTION
[pgweb](http://sosedoff.github.io/pgweb/) is a small, beautiful and quick way of inspecting a postgres database.

Similar to pgadmin, which was requested long ago in https://github.com/Tecnativa/doodba-scaffolding/pull/10, but never got merged because it didn't provide a very good out-of-the-box experience. pgweb, instead, can be (and is) configured through a simple environment variable, which makes that just browsing http://localhost:8081 renders a nice view of all the database structure, don't having to deal with connections, setup, passwords, etc.