### PR TITLE
Allow testing v2 migration

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -58,7 +58,7 @@ _migrations:
         - --search-root={{ _copier_conf.src_path }}
         - --collection=migrations
         - remove-odoo-auto-folder
-  - version: v2.0.0
+  - version: v2.0.0a0
     before:
       - - invoke
         - --search-root={{ _copier_conf.src_path }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -154,7 +154,7 @@ description = "A library for rendering project templates."
 name = "copier"
 optional = false
 python-versions = ">=3.6,<4.0"
-version = "4.1.0"
+version = "5.0.0"
 
 [package.dependencies]
 colorama = ">=0.4.3,<0.5.0"
@@ -168,7 +168,7 @@ pyyaml-include = ">=1.2,<2.0"
 regex = ">=2020.6.8,<2021.0.0"
 
 [package.extras]
-docs = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=5.5.2,<6.0.0)", "mkdocstrings (>=0.12.2,<0.13.0)"]
+docs = ["mkdocs-material (>=5.5.2,<6.0.0)", "mkdocstrings (>=0.12.2,<0.13.0)", "pymdown-extensions (>=6.3,<8.0)"]
 
 [[package]]
 category = "dev"
@@ -898,7 +898,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "6fcd5cf93c863b14bcf14317dca406239f6efb085e32b743ddc2349a299ca317"
+content-hash = "ff127196771d6789be16fc21ebf661e0d2e819a7fb78d4f6db8231b07b8ad4fb"
 lock-version = "1.0"
 python-versions = "^3.6.1"
 
@@ -1002,8 +1002,8 @@ colorama = [
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
 copier = [
-    {file = "copier-4.1.0-py3-none-any.whl", hash = "sha256:1434541f8ff7a97ca0db284fa31b5604d6ef6c0045043a61ac6a0b88f45aad77"},
-    {file = "copier-4.1.0.tar.gz", hash = "sha256:a9514a7ba4d5ecb19ccf5f3bcc453bcb90a18cf8031b00982d9fb1a3667c78cd"},
+    {file = "copier-5.0.0-py3-none-any.whl", hash = "sha256:d70dff5553f3b68bb55e538bcbbe571df204f015b1f4601fb5f3c8834efbc678"},
+    {file = "copier-5.0.0.tar.gz", hash = "sha256:9f9f2d2ff6a5aa40eebf894c9753064c78a50ba4e9a12bc679331b6cd2ab2047"},
 ]
 cryptography = [
     {file = "cryptography-3.0-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:ab49edd5bea8d8b39a44b3db618e4783ef84c19c8b47286bf05dfdb3efb01c83"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ name = "doodba-copier-template"
 version = "0.1.0"
 
 [tool.poetry.dependencies]
-copier = "^4.1.0"
+copier = "^5.0.0"
 plumbum = "^1.6.8"
 python = "^3.6.1"
 


### PR DESCRIPTION
Now that copier v5 will not autoupdate to prereleases by default thanks to https://github.com/copier-org/copier/pull/254, I set the domain update to be triggered since v2a0, so I'll be able to alpha-tag the template and test it properly.

@Tecnativa TT23705