### PR TITLE
Properly migrate Traefik 2 cert resolver

### DIFF
--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -1,4 +1,4 @@
-{% import "_macros.jinja" as macros %}
+{% import "_macros.jinja" as macros -%}
 version: "2.4"
 
 services:

--- a/migrations.py
+++ b/migrations.py
@@ -79,20 +79,19 @@ def update_domains_structure(c, dst_path, answers_rel_path):
     """
     answers_path = Path(dst_path, answers_rel_path)
     answers_yaml = _load_yaml(answers_path)
-    traefik_cert_resolver = answers_yaml.pop("traefik_cert_resolver", None)
     # Update domains_prod
     domain_prod = answers_yaml.pop("domain_prod", None)
     domain_prod_alternatives = answers_yaml.pop("domain_prod_alternatives", None)
     new_domains_prod = []
     if domain_prod:
         new_domains_prod.append(
-            {"hosts": [domain_prod], "cert_resolver": traefik_cert_resolver}
+            {"hosts": [domain_prod], "cert_resolver": "letsencrypt"}
         )
         if domain_prod_alternatives:
             new_domains_prod.append(
                 {
                     "hosts": domain_prod_alternatives,
-                    "cert_resolver": traefik_cert_resolver,
+                    "cert_resolver": "letsencrypt",
                     "redirect_to": domain_prod,
                 }
             )
@@ -102,7 +101,7 @@ def update_domains_structure(c, dst_path, answers_rel_path):
     new_domains_test = []
     if domain_test:
         new_domains_test.append(
-            {"hosts": [domain_test], "cert_resolver": traefik_cert_resolver}
+            {"hosts": [domain_test], "cert_resolver": "letsencrypt"}
         )
     answers_yaml.setdefault("domains_test", new_domains_test)
     answers_path.write_text(yaml.safe_dump(answers_yaml))

--- a/setup-devel.yaml.jinja
+++ b/setup-devel.yaml.jinja
@@ -1,4 +1,4 @@
-{% import "_macros.jinja" as macros %}
+{% import "_macros.jinja" as macros -%}
 # Use this environment to download all repositories from `repos.yaml` file:
 #
 #   export UID="$(id -u $USER)" GID="$(id -g $USER)" UMASK="$(umask)"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -150,7 +150,6 @@ def test_v1_5_3_migration(
     (MISSING, None, ["example.com", "www.example.org", "example.org"]),
 )
 @pytest.mark.parametrize("domain_test", (MISSING, None, "demo.example.com"))
-@pytest.mark.parametrize("traefik_cert_resolver", (MISSING, None, "letsencrypt"))
 def test_v2_0_0_migration(
     tmp_path: Path,
     cloned_template: Path,
@@ -158,7 +157,6 @@ def test_v2_0_0_migration(
     domain_prod,
     domain_prod_alternatives,
     domain_test,
-    traefik_cert_resolver,
 ):
     """Test migration to v2.0.0."""
     # Construct data dict, removing MISSING values
@@ -167,7 +165,6 @@ def test_v2_0_0_migration(
         "domain_prod": domain_prod,
         "domain_test": domain_test,
         "odoo_version": supported_odoo_version,
-        "traefik_cert_resolver": traefik_cert_resolver,
     }
     for key, value in tuple(data.items()):
         if value is MISSING:
@@ -207,14 +204,14 @@ def test_v2_0_0_migration(
             expected_domains_prod.append(
                 {
                     "hosts": [domain_prod],
-                    "cert_resolver": data.get("traefik_cert_resolver"),
+                    "cert_resolver": "letsencrypt",
                 }
             )
         if data.get("domain_prod_alternatives") and expected_domains_prod:
             expected_domains_prod.append(
                 {
                     "hosts": domain_prod_alternatives,
-                    "cert_resolver": data.get("traefik_cert_resolver"),
+                    "cert_resolver": "letsencrypt",
                     "redirect_to": domain_prod,
                 }
             )
@@ -224,7 +221,7 @@ def test_v2_0_0_migration(
             expected_domains_test.append(
                 {
                     "hosts": [domain_test],
-                    "cert_resolver": data.get("traefik_cert_resolver"),
+                    "cert_resolver": "letsencrypt",
                 }
             )
         assert answers["domains_test"] == expected_domains_test


### PR DESCRIPTION

[In template v1.x it was hardcoded to be `letsencrypt`][1]. After migrating template, it must be the same.

TT23705

[1]: https://github.com/Tecnativa/doodba-copier-template/blob/ab7a378e473ab3b15a5db811f33715024c9f2b44/prod.yaml.jinja#L97