### PR TITLE
Remove absurd labels

### DIFF
--- a/_traefik1_labels.yml.jinja
+++ b/_traefik1_labels.yml.jinja
@@ -58,7 +58,7 @@
       {%- else %}
 
       {#- Forbidden crawler routers #}
-      {%- if paths_without_crawlers %}
+      {%- if paths_without_crawlers and not domain_group.path_prefixes %}
       traefik.forbiddenCrawlers-{{ domain_group.loop.index0 }}.frontend.headers.customResponseHeaders:
         "X-Robots-Tag:noindex, nofollow"
       {{-
@@ -82,6 +82,7 @@
         )
       }}
       {%- endif %}
+      {%- if not domain_group.path_prefixes %}
       {{-
         router(
           prefix="longpolling",
@@ -91,6 +92,7 @@
           port=8072,
         )
       }}
+      {%- endif %}
       {%- endif %}
       {%- endcall %}
 {%- endmacro %}

--- a/_traefik2_labels.yml.jinja
+++ b/_traefik2_labels.yml.jinja
@@ -150,6 +150,7 @@
       {%- endif %}
 
       {#- Longpolling router #}
+      {%- if not domain_group.path_prefixes %}
       {{-
         router(
           domain_group=domain_group,
@@ -160,6 +161,7 @@
           middlewares=_ns.basic_middlewares,
         )
       }}
+      {%- endif %}
 
       {#- Forbidden crawlers router #}
       {%- if paths_without_crawlers and not domain_group.path_prefixes %}


### PR DESCRIPTION

If there's a path prefix, no need to include longpolling and forbiddenCrawlers routers.

TT23705