### PR TITLE
Specify and test the main domain

### DIFF
--- a/_macros.jinja
+++ b/_macros.jinja
@@ -42,12 +42,17 @@
     {%- endcall %}
 {%- endmacro %}
 
-{# Loop over a domain groups list, call back with the 1st domain found and exit. #}
+{# Get the main domain from a domain groups list.
+
+   The main domain is the 1st one found from a routing rule that redirects nowhere
+   and uses no path prefix.
+
+   This macro just prints that hostname.
+#}
 {%- macro first_main_domain(domain_groups_list) %}
-    {%- set parent_caller = caller %}
     {%- call(domain) domains_loop_single(domain_groups_list) %}
-        {%- if not domain.redirect_to %}
-            {{- parent_caller(domain) }}
+        {%- if not domain.group.redirect_to and not domain.group.path_prefixes %}
+            {{- domain.host }}
             {%- set domain.exit = true %}
         {%- endif %}
     {%- endcall %}

--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -83,9 +83,9 @@ services:
   backup:
     image: tecnativa/duplicity:postgres{% if backup_dst.startswith(('boto3+s3://', 's3://', 's3+http://')) %}-s3{% endif %}
     hostname: backup
-    {%- call(domain) macros.first_main_domain(domains_prod) %}
-    domainname: {{ domain.host }}
-    {%- endcall %}
+    {%- if macros.first_main_domain(domains_prod) %}
+    domainname: {{ macros.first_main_domain(domains_prod) }}
+    {%- endif %}
     init: true
     environment:
       DST: "{{ backup_dst }}"

--- a/copier.yml
+++ b/copier.yml
@@ -151,6 +151,9 @@ domains_prod:
 
     ⚠ Some advanced features are only available if you deploy with Traefik 2.
 
+    💡 The 1st host from the 1st domain that has no `path_prefixes` will be considered
+    the main one. In the example above, it'd be `www.main.com`.
+
 domains_test:
   type: yaml
   help: |
@@ -184,6 +187,9 @@ domains_test:
     supports multiline input
 
     ⚠ Some advanced features are only available if you deploy with Traefik 2.
+
+    💡 The 1st host from the 1st domain that has no `path_prefixes` will be considered
+    the main one. In the example above, it'd be `demo1.main.com`.
 
 paths_without_crawlers:
   default:

--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -1,3 +1,4 @@
+{%- import "_macros.jinja" as macros -%}
 {%- import "_traefik1_labels.yml.jinja" as traefik1_labels -%}
 {%- import "_traefik2_labels.yml.jinja" as traefik2_labels -%}
 {%- set _key = traefik2_labels.key(project_name, odoo_version, "prod") -%}
@@ -27,7 +28,10 @@ services:
       default:
     {%- if odoo_proxy == "traefik" and domains_prod %}
       inverseproxy_shared:
+    {%- endif %}
     labels:
+      doodba.domain.main: {{ macros.first_main_domain(domains_prod)|tojson }}
+      {%- if odoo_proxy == "traefik" and domains_prod %}
       traefik.enable: "true"
       {{- traefik1_labels.odoo(domains_prod, paths_without_crawlers) }}
       {{- traefik2_labels.common_middlewares(_key, cidr_whitelist) }}
@@ -39,7 +43,7 @@ services:
         paths_without_crawlers,
         project_name,
       ) }}
-    {%- endif %}
+      {%- endif %}
 
   db:
     extends:

--- a/test.yaml.jinja
+++ b/test.yaml.jinja
@@ -27,7 +27,10 @@ services:
       globalwhitelist_shared:
     {%- if odoo_proxy == "traefik" and domains_test %}
       inverseproxy_shared:
+    {%- endif %}
     labels:
+      doodba.domain.main: {{ macros.first_main_domain(domains_test)|tojson }}
+      {%- if odoo_proxy == "traefik" and domains_test %}
       traefik.enable: "true"
       {{- traefik1_labels.odoo(domains_test, ["/"]) }}
       {{- traefik2_labels.odoo(
@@ -63,7 +66,10 @@ services:
           - smtplocal
     {%- if odoo_proxy == "traefik" and domains_test %}
       inverseproxy_shared:
+    {%- endif %}
     labels:
+      doodba.domain.main: {{ macros.first_main_domain(domains_test)|tojson }}
+      {%- if odoo_proxy == "traefik" and domains_test %}
       traefik.docker.network: "inverseproxy_shared"
       traefik.enable: "true"
       {#- Traefik v1 labels #}
@@ -111,7 +117,7 @@ services:
         )
       }}
       {%- endcall %}
-    {%- endif %}
+      {%- endif %}
     volumes:
       - "smtpconf:/etc/mailhog:ro,z"
     entrypoint: [sh, -c]

--- a/tests/test_nitpicking.py
+++ b/tests/test_nitpicking.py
@@ -16,6 +16,53 @@ WHITESPACE_PREFIXED_LICENSES = (
 )
 
 
+def test_doodba_main_domain_label(cloned_template: Path, tmp_path: Path):
+    """Make sure the doodba.domain.main label is correct."""
+    copy(
+        str(cloned_template),
+        str(tmp_path),
+        vcs_ref="test",
+        force=True,
+        data={
+            "domains_prod": [
+                {
+                    "hosts": ["not0.prod.example.com", "not1.prod.example.com"],
+                    "redirect_to": "yes.prod.example.com",
+                },
+                {
+                    "hosts": ["not3.prod.example.com", "not4.prod.example.com"],
+                    "path_prefixes": ["/insecure/"],
+                    "entrypoints": ["web-insecure"],
+                },
+                {"hosts": ["yes.prod.example.com", "not5.prod.example.com"]},
+            ],
+            "domains_test": [
+                {
+                    "hosts": ["not0.test.example.com", "not1.test.example.com"],
+                    "redirect_to": "yes.test.example.com",
+                },
+                {
+                    "hosts": ["not3.test.example.com", "not4.test.example.com"],
+                    "path_prefixes": ["/insecure/"],
+                    "entrypoints": ["web-insecure"],
+                },
+                {"hosts": ["yes.test.example.com", "not5.test.example.com"]},
+            ],
+        },
+    )
+    with local.cwd(tmp_path):
+        prod_config = yaml.load(docker_compose("-f", "prod.yaml", "config"))
+        test_config = yaml.load(docker_compose("-f", "test.yaml", "config"))
+        assert (
+            prod_config["services"]["odoo"]["labels"]["doodba.domain.main"]
+            == "yes.prod.example.com"
+        )
+        assert (
+            test_config["services"]["odoo"]["labels"]["doodba.domain.main"]
+            == "yes.test.example.com"
+        )
+
+
 @pytest.mark.parametrize("project_license", WHITESPACE_PREFIXED_LICENSES)
 def test_license_whitespace_prefix(
     tmp_path: Path, cloned_template: Path, project_license


### PR DESCRIPTION

Odoo itself supports multiple domains, but has a notion of what the main domain is (a.k.a. `web.base.url`).

From now on, the notion of what the main domain is gets coded, documented and tested. The final result gets exposed as the `doodba.domain.main` label in the `odoo` service, just in case you need to extract it for any purposes.

@Tecnativa TT23705