### PR TITLE
Bump default template update version

### DIFF
--- a/docs/scaffolding2copier.sh
+++ b/docs/scaffolding2copier.sh
@@ -12,7 +12,7 @@
 
 source .env
 copier $CUSTOM_COPIER_FLAGS \
-  -r "${TEMPLATE_VERSION-v1.5.4}" \
+  -r "${TEMPLATE_VERSION-v1.8.1}" \
   -d project_name="${PROJECT_NAME-$(basename $PWD)}" \
   -d project_license="${LICENSE-BSL-1.0}" \
   -d gitlab_url="${GITLAB_PREFIX-https://gitlab.com/example}/${PROJECT_NAME-$(basename $PWD)}" \


### PR DESCRIPTION
From v2.0.0 onwards, this version should never ever change again.