### PR TITLE
Open all ports in devel prefixed by version

### DIFF
--- a/.vscode/launch.json.jinja
+++ b/.vscode/launch.json.jinja
@@ -1,3 +1,4 @@
+{%- import "_macros.jinja" as macros -%}
 {
   "version": "0.2.0",
   "configurations": [
@@ -13,7 +14,7 @@
           "remoteRoot": "/opt/odoo"
         }
       ],
-      "port": 6899,
+      "port": {{ macros.version_major(odoo_version) }}899,
       "host": "localhost"
     },
     {
@@ -26,7 +27,7 @@
           "remoteRoot": "/opt/odoo"
         }
       ],
-      "port": 6899,
+      "port": {{ macros.version_major(odoo_version) }}899,
       "host": "localhost"
     }
   ]

--- a/devel.yaml.jinja
+++ b/devel.yaml.jinja
@@ -10,7 +10,7 @@ services:
       default:
       public:
     ports:
-      - "127.0.0.1:6899:6899"
+      - "127.0.0.1:{{ macros.version_major(odoo_version) }}899:6899"
       - "127.0.0.1:{{ macros.version_major(odoo_version) }}069:8069"
     environment:
       PORT: "6899 8069"
@@ -40,6 +40,7 @@ services:
       PYTHONOPTIMIZE: ""
       PYTHONPATH: /opt/odoo/custom/src/odoo
       SMTP_PORT: "1025"
+      WDB_WEB_PORT: "{{ macros.version_major(odoo_version) }}984"
       # To avoid installing demo data export DOODBA_WITHOUT_DEMO=all
       WITHOUT_DEMO: "${DOODBA_WITHOUT_DEMO-false}"
     volumes:
@@ -80,7 +81,7 @@ services:
     image: sosedoff/pgweb
     networks: *public
     ports:
-      - "127.0.0.1:8081:8081"
+      - "127.0.0.1:{{ macros.version_major(odoo_version) }}081:8081"
     environment:
       DATABASE_URL: postgres://{{ postgres_username }}:odoopassword@db:5432/devel?sslmode=disable
     depends_on:
@@ -92,13 +93,13 @@ services:
       service: smtpfake
     networks: *public
     ports:
-      - "127.0.0.1:8025:8025"
+      - "127.0.0.1:{{ macros.version_major(odoo_version) }}025:8025"
 
   wdb:
     image: kozea/wdb
     networks: *public
     ports:
-      - "127.0.0.1:1984:1984"
+      - "127.0.0.1:{{ macros.version_major(odoo_version) }}984:1984"
     # HACK https://github.com/Kozea/wdb/issues/136
     init: true
 

--- a/docs/daily-usage.md
+++ b/docs/daily-usage.md
@@ -109,8 +109,8 @@ We use [MailHog](https://github.com/mailhog/MailHog) to provide a fake SMTP serv
 intercepts all mail sent by Odoo and displays a simple interface that lets you see and
 debug all that mail comfortably, including headers sent, attachments, etc.
 
-- For [development][], it's in http://localhost:8025
-- For [testing][], it's in http://\$DOMAIN_TEST/smtpfake/
+- For [development][], it's in `http://localhost:${ODOO_MAJOR}025`
+- For [testing][], it's in `http://\$DOMAIN_TEST/smtpfake/`
 - For [production][], it's not used.
 
 All environments are configured by default to use the bundled SMTP relay. They are
@@ -161,7 +161,7 @@ wdb.set_trace()
 ```
 
 It's available by default on the [development][] environment, where you can browse
-http://localhost:1984 to use it.
+`http://localhost:${ODOO_MAJOR}984` to use it.
 
 **⚠️ DO NOT USE IT IN PRODUCTION ENVIRONMENTS ⚠️** (I had to say it).
 
@@ -171,7 +171,7 @@ http://localhost:1984 to use it.
 inspect a Postgres database.
 
 We ship it preconfigured in the [development][] environment. Just start it and open
-http://localhost:8081 to use it.
+`http://localhost:${ODOO_MAJOR}081` to use it.
 
 ### Production
 


### PR DESCRIPTION

This should let the developer at least boot 2 instances with different versions.

Not perfect yet, but better than before indeed.

Docs updated.