### PR TITLE
Fix incompatibility between pylint-odoo and isort

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -87,13 +87,17 @@ repos:
           - --rcfile=.pylintrc
           - --exit-zero
         verbose: true
-        additional_dependencies: ["pylint-odoo==3.5.0"]
+        additional_dependencies:
+          - isort==4.3.21
+          - pylint-odoo==3.5.0
       - id: pylint
         name: pylint with mandatory checks
         args:
           - --valid_odoo_versions={{ "%.1f"|format(odoo_version) }}
           - --rcfile=.pylintrc-mandatory
-        additional_dependencies: ["pylint-odoo==3.5.0"]
+        additional_dependencies:
+          - isort==4.3.21
+          - pylint-odoo==3.5.0
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v7.8.1
     hooks:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import json
 import os
+import textwrap
 from pathlib import Path
+from typing import Dict, Union
 
 import pytest
 import yaml
@@ -159,3 +161,15 @@ def teardown_function(function):
     if pre_commit_log.is_file():
         print(pre_commit_log.read_text())
         pre_commit_log.unlink()
+
+
+# Helpers
+def build_file_tree(spec: Dict[Union[str, Path], str], dedent: bool = True):
+    """Builds a file tree based on the received spec."""
+    for path, contents in spec.items():
+        path = Path(path)
+        if dedent:
+            contents = textwrap.dedent(contents)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w") as fd:
+            fd.write(contents)


### PR DESCRIPTION

After using v2.0.0, sadly we missed another alpha and got hit by https://github.com/OCA/pylint-odoo/issues/296.

This fixes the situation by pinning the isort version. Also it tests the actual execution of pylint-odoo in pre-commit context, instead of just asserting its configuration.

TT23969