### PR TITLE
Fix isort 5 compatibility with black

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -32,6 +32,7 @@ repos:
     hooks:
       - id: isort
         name: isort except __init__.py
+        args: [--settings, .]
         exclude: /__init__\.py$
   - repo: https://github.com/prettier/prettier
     rev: 2.1.1

--- a/tests/test_nitpicking.py
+++ b/tests/test_nitpicking.py
@@ -348,9 +348,10 @@ def test_pre_commit_in_subproject(
                 from logging import getLogger
                 from os.path import join
 
+                from requests import get
+
                 import odoo
                 from odoo import models
-                from requests import get
 
                 _logger = getLogger(__name__)
 


### PR DESCRIPTION
This fix is needed to avoid https://github.com/PyCQA/isort/issues/1481.