### PR TITLE
Fix Traefik v1 port label

### DIFF
--- a/_traefik1_labels.yml.jinja
+++ b/_traefik1_labels.yml.jinja
@@ -36,7 +36,7 @@
         {{ entrypoints|sort|join(",") }}
       {%- endif %}
       {%- if port %}
-      traefik.{{ prefix }}-{{ index0 }}.frontend.port: {{ port }}
+      traefik.{{ prefix }}-{{ index0 }}.port: {{ port }}
       {%- endif %}
 {%- endmacro %}
 


### PR DESCRIPTION

It shouldn't include `.frontend`.

TT25531