### PR TITLE
Update prettier XML plugin and fix incompatibility

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -35,17 +35,14 @@ repos:
         args: [--settings, .]
         exclude: /__init__\.py$
   - repo: https://github.com/prettier/prettier
-    rev: 2.1.1
+    rev: 2.1.2
     hooks:
-      - &prettier
-        id: prettier
+      - id: prettier
+        name: prettier + plugin-xml
         additional_dependencies:
-          - "@prettier/plugin-xml@0.7.2"
+          - "@prettier/plugin-xml@0.12.0"
         args:
           - --plugin=@prettier/plugin-xml
-      - <<: *prettier
-        name: prettier + plugin-xml
-        files: \.xml$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:


### PR DESCRIPTION

With the combination that landed with latest update, XML code couldn't make use of `<!-- prettier-ignore-start -->` and `<!-- prettier-ignore-end -->` tags.

Besides, since https://github.com/prettier/prettier/pull/8829 was merged, we don't need to have 2 separate prettier steps anymore; XML files get formatted in the 1st one automatically.

With this patch, the now-duplicated step is removed and the XML plugin is updated, so we get saner ignores. Also, XML files will look even prettier now.