### PR TITLE
Fix typo in traefik 1 entrypoints

### DIFF
--- a/_traefik1_labels.yml.jinja
+++ b/_traefik1_labels.yml.jinja
@@ -11,7 +11,7 @@
   Path:
     {%- for path in path_prefixes %}
       {%- set sep = "" if path.endswith("/") else "/" %}
-      {{- path }}{anything:({{ sep }}.*)?}
+      {{- path }}{anything:{{ sep }}.*}
       {%- if not loop.last %},{% endif %}
     {%- endfor %}
 {%- endmacro %}
@@ -32,7 +32,7 @@
 {%- macro router(prefix, index0, rule, entrypoints=(), port=none) %}
       traefik.{{ prefix }}-{{ index0 }}.frontend.rule: {{ rule }}
       {%- if entrypoints %}
-      traefik.{{ prefix }}-{{ index0 }}.frontend.entrypoints:
+      traefik.{{ prefix }}-{{ index0 }}.frontend.entryPoints:
         {{ entrypoints|sort|join(",") }}
       {%- endif %}
       {%- if port %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,6 +114,7 @@ def traefik_host(docker: LocalCommand, request):
         ):
             traefik_container = traefik_run(
                 "--accessLog=true",
+                "--entrypoints.web-alt.address=:8080",
                 "--entrypoints.web-insecure.address=:80",
                 "--entrypoints.web-main.address=:443",
                 "--log.level=debug",
@@ -123,12 +124,13 @@ def traefik_host(docker: LocalCommand, request):
             ).strip()
         else:
             traefik_container = traefik_run(
-                "--defaultEntryPoints=http,https",
+                "--defaultEntryPoints=web-insecure,web-main",
                 "--docker.exposedByDefault=false",
                 "--docker.watch",
                 "--docker",
-                "--entryPoints=Name:http Address::80 Redirect.EntryPoint:https",
-                "--entryPoints=Name:https Address::443 Compress:on TLS TLS.minVersion:VersionTLS12",
+                "--entryPoints=Name:web-alt Address::8080 Compress:on",
+                "--entryPoints=Name:web-insecure Address::80 Redirect.EntryPoint:web-main",
+                "--entryPoints=Name:web-main Address::443 Compress:on TLS TLS.minVersion:VersionTLS12",
                 "--logLevel=debug",
             ).strip()
         traefik_details = json.loads(docker("container", "inspect", traefik_container))


### PR DESCRIPTION
It must be `entryPoints` and not `entrypoints`.

TT25671