### PR TITLE
Set xmlWhitespaceSensitivity=strict for prettier

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,4 +1,5 @@
 # Defaults for all prettier-supported languages
+# Prettier will complete this with settings from .editorconfig file.
 bracketSpacing: false
 printWidth: 88
 proseWrap: always

--- a/.prettierrc.yml.jinja
+++ b/.prettierrc.yml.jinja
@@ -1,1 +1,0 @@
-{%- include "vendor/maintainer-quality-tools/sample_files/pre-commit-13.0/.prettierrc.yml" -%}


### PR DESCRIPTION

Newer prettier XML plugin is giving some headaches because it disrespects whitespace inside attributes also. This can transform things like `href` to some wrong value.

We choose to default to strict. According to [prettier-xml docs][1], `xmlWhitespaceSensitivity` defaults to `strict`, so technically we don't really need to establish that setting.

Then the desired subproject configuration matches the same as the templates, so the `.jinja` file can be just removed.

@Tecnativa TT25707