### PR TITLE
[FIX] Order VSCode folders A-Z

### DIFF
--- a/tasks.py.jinja
+++ b/tasks.py.jinja
@@ -133,7 +133,7 @@ def write_code_workspace_file(c, cw_path=None):
     for subrepo in SRC_PATH.glob("*"):
         if not subrepo.is_dir():
             continue
-        if (subrepo / ".git").exists():
+        if (subrepo / ".git").exists() and subrepo.name != "odoo":
             cw_config["folders"].append(
                 {"path": str(subrepo.relative_to(PROJECT_ROOT))}
             )
@@ -204,6 +204,12 @@ def write_code_workspace_file(c, cw_path=None):
             },
         ],
     }
+    # Sort project folders
+    cw_config["folders"].sort(key=lambda x: x["path"])
+    # Put Odoo folder just before private and top folder
+    odoo = SRC_PATH / "odoo"
+    if odoo.is_dir():
+        cw_config["folders"].append({"path": str(odoo.relative_to(PROJECT_ROOT))})
     # HACK https://github.com/microsoft/vscode/issues/95963 put private second to last
     private = SRC_PATH / "private"
     if private.is_dir():

--- a/tests/test_nitpicking.py
+++ b/tests/test_nitpicking.py
@@ -234,14 +234,22 @@ def test_code_workspace_file(
         assert not (tmp_path / f"doodba.{tmp_path.name}.code-workspace").is_file()
         # Do a stupid and dirty git clone to check it's sorted fine
         git("clone", cloned_template, Path("odoo", "custom", "src", "zzz"))
+        # "Clone" a couple more repos, including odoo to check order
+        git("clone", cloned_template, Path("odoo", "custom", "src", "aaa"))
+        git("clone", cloned_template, Path("odoo", "custom", "src", "bbb"))
+        git("clone", cloned_template, Path("odoo", "custom", "src", "odoo"))
         invoke("write-code-workspace-file", "-c", "doodba.other2.code-workspace")
         assert not (tmp_path / f"doodba.{tmp_path.name}.code-workspace").is_file()
         assert (tmp_path / "doodba.other1.code-workspace").is_file()
         assert (tmp_path / "doodba.other2.code-workspace").is_file()
         with (tmp_path / "doodba.other2.code-workspace").open() as fp:
             workspace_definition = json.load(fp)
+        # Check workspace folder definition and order
         assert workspace_definition["folders"] == [
+            {"path": "odoo/custom/src/aaa"},
+            {"path": "odoo/custom/src/bbb"},
             {"path": "odoo/custom/src/zzz"},
+            {"path": "odoo/custom/src/odoo"},
             {"path": "odoo/custom/src/private"},
             {"name": f"doodba.{tmp_path.name}", "path": "."},
         ]


### PR DESCRIPTION
- Git repos workspace folders ordered from A-Z
- Odoo, Private and Root folder last

TT25731