### PR TITLE
Use ghcr.io version of tecnativa/postgres-autoconf image

### DIFF
--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -33,7 +33,7 @@ services:
     {%- endif %}
 
   db:
-    image: tecnativa/postgres-autoconf:{{ postgres_version }}-alpine
+    image: ghcr.io/tecnativa/postgres-autoconf:{{ postgres_version }}-alpine
     shm_size: 512mb
     environment:
       POSTGRES_DB: *dbname


### PR DESCRIPTION

This edition is the same image, but published directly on Github, which works nicer with users in countries that USA doesn't like.

@Tecnativa TT22772