### PR TITLE
Increase default postgres work_mem

### DIFF
--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -39,7 +39,7 @@ services:
       POSTGRES_DB: *dbname
       POSTGRES_USER: *dbuser
       CONF_EXTRA: |
-        work_mem = 32MB
+        work_mem = 512MB
     volumes:
       - db:/var/lib/postgresql/data:z
 


### PR DESCRIPTION

While debugging https://github.com/OCA/stock-logistics-workflow/pull/712, [this explain-analyzed query][1] shows that a database with 1.25M quants takes ~210 MB of memory to perform a quicksort memory sort operation, while running [`_merge_quants()`][2].

I'll default to giving about the double of that, to avoid further bottlenecks.

@Tecnativa TT26171

[1]: https://explain.depesz.com/s/3Ivw
[2]: https://github.com/odoo/odoo/blob/1527db8cd719c487ace02fca9fde21430e31d350/addons/stock/models/stock_quant.py#L317-L335