### PR TITLE
Update subrepo and add full weekly backups when deletion is enabled 

### DIFF
--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -94,6 +94,8 @@ services:
       EMAIL_TO: "{{ backup_email_to }}"
       {%- endif %}
       {%- if backup_deletion %}
+      JOB_500_WHAT: dup full $$SRC $$DST
+      JOB_500_WHEN: weekly
       JOB_800_WHAT: dup --force remove-older-than 3M $$DST
       JOB_800_WHEN: weekly
       {%- endif %}


### PR DESCRIPTION


It turns out the deletion process was deleting nothing because full backups were never being triggered, due to that only being automatic upstream in `*-s3` flavoured tags.

