### PR TITLE
Pin nodejs versions for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 default_language_version:
   python: python3
+  node: "14.14.0"
 repos:
   - repo: local
     hooks:
@@ -33,8 +34,11 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear==20.1.4]
+  # TODO Migrate to new prettier pre-commit repo after fixed:
+  # HACK https://github.com/prettier/pre-commit/pull/17
+  # HACK https://github.com/prettier/pre-commit/pull/18
   - repo: https://github.com/prettier/prettier
-    rev: 2.1.1
+    rev: 2.1.2
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,8 +33,8 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear==20.1.4]
-  - repo: https://github.com/prettier/pre-commit
-    rev: v2.1.1
+  - repo: https://github.com/prettier/prettier
+    rev: 2.1.1
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -34,18 +34,14 @@ repos:
         name: isort except __init__.py
         args: [--settings, .]
         exclude: /__init__\.py$
-  - repo: https://github.com/prettier/pre-commit
-    rev: v2.1.2
+  - repo: https://github.com/prettier/prettier
+    rev: 2.1.2
     hooks:
       - id: prettier
         name: prettier + plugin-xml
         additional_dependencies:
-          - prettier@2.1.2
           - "@prettier/plugin-xml@0.12.0"
         args:
-          - --write
-          - --list-different
-          - --ignore-unknown
           - --plugin=@prettier/plugin-xml
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -11,6 +11,7 @@ exclude: |
   (LICENSE.*|COPYING.*)
 default_language_version:
   python: python3
+  node: "14.14.0"
 repos:
   - repo: local
     hooks:
@@ -34,6 +35,9 @@ repos:
         name: isort except __init__.py
         args: [--settings, .]
         exclude: /__init__\.py$
+  # TODO Migrate to new prettier pre-commit repo after fixed:
+  # HACK https://github.com/prettier/pre-commit/pull/17
+  # HACK https://github.com/prettier/pre-commit/pull/18
   - repo: https://github.com/prettier/prettier
     rev: 2.1.2
     hooks:


### PR DESCRIPTION

This seems to be a better fix (for now) than #149 because it just fixes the npm 7 installation problem without having to worry about https://github.com/prettier/pre-commit/pull/17 or https://github.com/prettier/pre-commit/pull/18 for the moment.

Once those are solved, we can start using the new repo.