### PR TITLE
Add traefik 1 main domain

### DIFF
--- a/_traefik1_labels.yml.jinja
+++ b/_traefik1_labels.yml.jinja
@@ -41,6 +41,7 @@
 {%- endmacro %}
 
 {%- macro odoo(domain_groups_list, paths_without_crawlers) %}
+      traefik.domain: {{ macros.first_main_domain(domains_test)|tojson }}
       {%- call(domain_group) macros.domains_loop_grouped(domain_groups_list) %}
 
       {#- Route redirections #}


### PR DESCRIPTION

Without this label, Traefik 1 keeps trying to download invalid certs, even when there are more specific routers that would invalidate this rule.