### PR TITLE
Odoo only depends on db if not using external db

### DIFF
--- a/devel.yaml.jinja
+++ b/devel.yaml.jinja
@@ -48,7 +48,9 @@ services:
       - ./odoo/auto:/opt/odoo/auto:rw,z
     depends_on:
       - cdnjs_cloudflare_proxy
+      {% if postgres_version -%}
       - db
+      {%- endif %}
       - fonts_googleapis_proxy
       - fonts_gstatic_proxy
       - google_proxy

--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -20,7 +20,9 @@ services:
       SMTP_SERVER: smtplocal
       {%- endif %}
     depends_on:
+      {% if postgres_version -%}
       - db
+      {%- endif %}
       {%- if smtp_relay_host %}
       - smtp
       {%- endif %}

--- a/test.yaml.jinja
+++ b/test.yaml.jinja
@@ -20,7 +20,9 @@ services:
       SMTP_SERVER: smtplocal
     restart: unless-stopped
     depends_on:
+      {% if postgres_version -%}
       - db
+      {%- endif %}
       - smtp
     networks:
       default:


### PR DESCRIPTION
Odoo can't always depend on `db` because we don't always have it. This fixes that bug.

Fixes https://github.com/Tecnativa/doodba-copier-template/pull/150#issuecomment-717671877