### PR TITLE
IMP: Add Odoo tests and install task

### DIFF
--- a/tasks.py.jinja
+++ b/tasks.py.jinja
@@ -17,6 +17,7 @@ from pathlib import Path
 from shutil import which
 
 from invoke import task
+from invoke import exceptions
 from invoke.util import yaml
 
 ODOO_VERSION = {{ odoo_version }}
@@ -357,10 +358,18 @@ def start(c, detach=True, debugpy=False):
     develop,
     help={
         "modules": "Comma-separated list of modules to test. Default: 'base'.",
+        "core": "Install all core addons. Default: False",
+        "extra": "Install all extra addons. Default: False",
+        "private": "Install all private addons. Default: False",
     },
 )
 def install(c, modules=None, core=False, extra=False, private=False):
     """Install Odoo addons"""
+    if not (modules or core or extra or private):
+        raise exceptions.ParseError(
+            message="You must provide at least one option. "
+            "See --help for details."
+        )
     cmd = "docker-compose run --rm addons init"
     if core:
         cmd += " --core"
@@ -379,40 +388,20 @@ def install(c, modules=None, core=False, extra=False, private=False):
         )
 
 
-def _get_cwd_addon(file=None):
-    if not file:
-        cwd = Path.cwd()
-    else:
-        cwd = Path.parent(file)
-    manifest_file = False
-    while not manifest_file:
-        manifest_file = (
-            Path(cwd / "__manifest__.py").exists()
-            or Path(cwd / "__openerp__.py").exists()
-        )
-        if manifest_file:
-            return cwd.stem
-        cwd = cwd.parent
-        if cwd == PROJECT_ROOT:
-            return None
-
-
 @task(
     develop,
     help={
-        "debugpy": "Whether or not to run tests in a VSCode debugging session. "
-        "Default: False",
+        "debugpy": "Whether or not to run tests in a VSCode debugging session. " \
+            "Default: False",
         "modules": "Comma-separated list of modules to test. Default: 'base'.",
-        "logs": "Whether or not to follow Odoo logs during testing. " "Default: True",
+        "logs": "Whether or not to follow Odoo logs during testing. " \
+            "Default: True",
     },
 )
-def test(c, modules=None, debugpy=False, logs=True, cur_file=None):
+def test(c, modules="base", debugpy=False, logs=True):
     """Run Odoo tests
     NOTE: Odoo must be restarted manually after this to go back to normal mode
     """
-    if not modules:
-        cur_module = _get_cwd_addon(file=cur_file)
-        modules = cur_module if cur_module is not None else "base"
     tmp_docker_compose_file = tempfile.NamedTemporaryFile(
         dir=PROJECT_ROOT, mode="w", suffix=".yaml"
     )
@@ -437,7 +426,8 @@ def test(c, modules=None, debugpy=False, logs=True, cur_file=None):
                     UID_ENV,
                 ),
             )
-            start(c) # If without logs, Odoo must be restarted manually
+    _logger.info("Waiting for services to spin up...")
+    time.sleep(SERVICES_WAIT_TIME)
     tmp_docker_compose_file.close()
 
 

--- a/tasks.py.jinja
+++ b/tasks.py.jinja
@@ -11,11 +11,13 @@ import json
 import os
 import time
 from logging import getLogger
+import tempfile
 from itertools import chain
 from pathlib import Path
 from shutil import which
 
 from invoke import task
+from invoke.util import yaml
 
 ODOO_VERSION = {{ odoo_version }}
 PROJECT_ROOT = Path(__file__).parent.absolute()
@@ -101,6 +103,12 @@ def write_code_workspace_file(c, cw_path=None):
                 "preLaunchTask": "Start Odoo in debug mode",
             },
             {
+                "name": "Run and debug Odoo tests",
+                "configurations": ["Attach Python debugger to running container"],
+                "preLaunchTask": "Run Odoo Tests in debug mode",
+                "internalConsoleOptions": "openOnSessionStart",
+            },
+            {
                 "name": "Start Odoo and debug JS in Firefox",
                 "configurations": ["Connect to firefox debugger"],
                 "preLaunchTask": "Start Odoo",
@@ -181,6 +189,42 @@ def write_code_workspace_file(c, cw_path=None):
                     "color": "#065535"
                     }
                 },
+            },
+            {
+                "label": "Run Odoo Tests for current module",
+                "type": "process",
+                "command": "invoke",
+                "args": ["test", "--cur-file", "${file}"],
+                "presentation": {
+                    "echo": True,
+                    "reveal": "always",
+                    "focus": True,
+                    "panel": "shared",
+                    "showReuseMessage": True,
+                    "clear": False,
+                },
+                "problemMatcher": [],
+            },
+            {
+                "label": "Run Odoo Tests in debug mode for current module",
+                "type": "process",
+                "command": "invoke",
+                "args": [
+                    "test",
+                    "--cur-file",
+                    "${file}",
+                    "--debugpy",
+                    "--no-logs",
+                ],
+                "presentation": {
+                    "echo": True,
+                    "reveal": "silent",
+                    "focus": False,
+                    "panel": "shared",
+                    "showReuseMessage": True,
+                    "clear": False,
+                },
+                "problemMatcher": [],
             },
             {
                 "label": "Start Odoo in debug mode",
@@ -308,6 +352,106 @@ def start(c, detach=True, debugpy=False):
         c.run(cmd, env=dict(UID_ENV, DOODBA_DEBUGPY_ENABLE=str(int(debugpy))))
     _logger.info("Waiting for services to spin up...")
     time.sleep(SERVICES_WAIT_TIME)
+
+@task(
+    develop,
+    help={
+        "modules": "Comma-separated list of modules to test. Default: 'base'.",
+    },
+)
+def install(c, modules=None, core=False, extra=False, private=False):
+    """Install Odoo addons"""
+    cmd = "docker-compose run --rm addons init"
+    if core:
+        cmd += " --core"
+    if extra:
+        cmd += " --extra"
+    if private:
+        cmd += " --private"
+    if modules:
+        cmd += f" -w {modules}"
+    with c.cd(str(PROJECT_ROOT)):
+        c.run(
+            cmd,
+            env=dict(
+                UID_ENV,
+            ),
+        )
+
+
+def _get_cwd_addon(file=None):
+    if not file:
+        cwd = Path.cwd()
+    else:
+        cwd = Path.parent(file)
+    manifest_file = False
+    while not manifest_file:
+        manifest_file = (
+            Path(cwd / "__manifest__.py").exists()
+            or Path(cwd / "__openerp__.py").exists()
+        )
+        if manifest_file:
+            return cwd.stem
+        cwd = cwd.parent
+        if cwd == PROJECT_ROOT:
+            return None
+
+
+@task(
+    develop,
+    help={
+        "debugpy": "Whether or not to run tests in a VSCode debugging session. "
+        "Default: False",
+        "modules": "Comma-separated list of modules to test. Default: 'base'.",
+        "logs": "Whether or not to follow Odoo logs during testing. " "Default: True",
+    },
+)
+def test(c, modules=None, debugpy=False, logs=True, cur_file=None):
+    """Run Odoo tests
+    NOTE: Odoo must be restarted manually after this to go back to normal mode
+    """
+    if not modules:
+        cur_module = _get_cwd_addon(file=cur_file)
+        modules = cur_module if cur_module is not None else "base"
+    tmp_docker_compose_file = tempfile.NamedTemporaryFile(
+        dir=PROJECT_ROOT, mode="w", suffix=".yaml"
+    )
+    cmd = (
+        "docker-compose -f docker-compose.yml "
+        f"-f {tmp_docker_compose_file.name} up -d"
+    )
+    odoo_command = f"addons init -tw {modules}"
+    _override_docker_command(c, "odoo", odoo_command, file=tmp_docker_compose_file)
+    with c.cd(str(PROJECT_ROOT)):
+        c.run(
+            cmd,
+            env=dict(
+                UID_ENV,
+                DOODBA_DEBUGPY_ENABLE=str(int(debugpy)),
+            ),
+        )
+        if logs:
+            c.run(
+                "docker-compose logs -f odoo",
+                env=dict(
+                    UID_ENV,
+                ),
+            )
+            start(c) # If without logs, Odoo must be restarted manually
+    tmp_docker_compose_file.close()
+
+
+def _override_docker_command(c, service, command, file=None):
+    docker_config = {
+        "version": "2.4",  # TODO: Update this if main file is updated
+        "services": {service: {"command": command.split(" ")}},
+    }
+    docker_config_yaml = yaml.dump(docker_config)
+    if file:
+        file.write(docker_config_yaml)
+        file.flush()
+    return docker_config_yaml
+
 
 @task(
     develop,

--- a/tasks.py.jinja
+++ b/tasks.py.jinja
@@ -24,9 +24,49 @@ ODOO_VERSION = {{ odoo_version }}
 PROJECT_ROOT = Path(__file__).parent.absolute()
 SRC_PATH = PROJECT_ROOT / "odoo" / "custom" / "src"
 UID_ENV = {"GID": str(os.getgid()), "UID": str(os.getuid()), "UMASK": "27"}
-SERVICES_WAIT_TIME = int(os.environ.get("SERVICES_WAIT_TIME", 3))
+SERVICES_WAIT_TIME = int(os.environ.get("SERVICES_WAIT_TIME", 4))
 
 _logger = getLogger(__name__)
+
+
+def _override_docker_command(service, command, file, orig_file=None):
+    # Read config from main file
+    if orig_file:
+        with open(orig_file, "r") as fd:
+            orig_docker_config = yaml.load(fd.read())
+            docker_compose_file_version = orig_docker_config.get("version")
+    else:
+        docker_compose_file_version = "2.4"
+    docker_config = {
+        "version": docker_compose_file_version,
+        "services": {service: {"command": command}},
+    }
+    docker_config_yaml = yaml.dump(docker_config)
+    file.write(docker_config_yaml)
+    file.flush()
+
+
+def _remove_auto_reload(file, orig_file):
+    with open(orig_file, "r") as fd:
+        orig_docker_config = yaml.load(fd.read())
+    odoo_command = orig_docker_config["services"]["odoo"]["command"]
+    odoo_command[-1] = odoo_command[-1].replace("reload,", "")
+    _override_docker_command("odoo", odoo_command, file, orig_file=orig_file)
+
+
+def _get_cwd_addon(file):
+    cwd = Path(file)
+    manifest_file = False
+    while PROJECT_ROOT < cwd:
+        manifest_file = (
+            (cwd / "__manifest__.py").exists()
+            or (cwd / "__openerp__.py").exists()
+        )
+        if manifest_file:
+            return cwd.stem
+        cwd = cwd.parent
+        if cwd == PROJECT_ROOT:
+            return None
 
 
 @task
@@ -106,7 +146,7 @@ def write_code_workspace_file(c, cw_path=None):
             {
                 "name": "Run and debug Odoo tests",
                 "configurations": ["Attach Python debugger to running container"],
-                "preLaunchTask": "Run Odoo Tests in debug mode",
+                "preLaunchTask": "Run Odoo Tests in debug mode for current module",
                 "internalConsoleOptions": "openOnSessionStart",
             },
             {
@@ -205,6 +245,7 @@ def write_code_workspace_file(c, cw_path=None):
                     "clear": False,
                 },
                 "problemMatcher": [],
+                "options": {"statusbar": {"hide": True}},
             },
             {
                 "label": "Run Odoo Tests in debug mode for current module",
@@ -215,7 +256,6 @@ def write_code_workspace_file(c, cw_path=None):
                     "--cur-file",
                     "${file}",
                     "--debugpy",
-                    "--no-logs",
                 ],
                 "presentation": {
                     "echo": True,
@@ -226,6 +266,7 @@ def write_code_workspace_file(c, cw_path=None):
                     "clear": False,
                 },
                 "problemMatcher": [],
+                "options": {"statusbar": {"hide": True}},
             },
             {
                 "label": "Start Odoo in debug mode",
@@ -354,23 +395,32 @@ def start(c, detach=True, debugpy=False):
     _logger.info("Waiting for services to spin up...")
     time.sleep(SERVICES_WAIT_TIME)
 
+
 @task(
     develop,
     help={
-        "modules": "Comma-separated list of modules to test. Default: 'base'.",
+        "modules": "Comma-separated list of modules to install.",
         "core": "Install all core addons. Default: False",
         "extra": "Install all extra addons. Default: False",
         "private": "Install all private addons. Default: False",
     },
 )
 def install(c, modules=None, core=False, extra=False, private=False):
-    """Install Odoo addons"""
+    """Install Odoo addons
+
+    By default, installs addon from directory being worked on,
+    unless other options are specified.
+    """
     if not (modules or core or extra or private):
-        raise exceptions.ParseError(
-            message="You must provide at least one option. "
-            "See --help for details."
-        )
-    cmd = "docker-compose run --rm addons init"
+        cur_module = _get_cwd_addon(Path.cwd())
+        if not cur_module:
+            raise exceptions.ParseError(
+                message="You must provide at least one option for modules"
+                " or be in a subdirectory of one."
+                " See --help for details."
+            )
+        modules = cur_module
+    cmd = "docker-compose run --rm odoo addons init"
     if core:
         cmd += " --core"
     if extra:
@@ -391,26 +441,56 @@ def install(c, modules=None, core=False, extra=False, private=False):
 @task(
     develop,
     help={
-        "debugpy": "Whether or not to run tests in a VSCode debugging session. " \
-            "Default: False",
-        "modules": "Comma-separated list of modules to test. Default: 'base'.",
-        "logs": "Whether or not to follow Odoo logs during testing. " \
-            "Default: True",
+        "modules": "Comma-separated list of modules to test.",
+        "debugpy": "Whether or not to run tests in a VSCode debugging session. "
+        "Default: False",
+        "cur-file": "Path to the current file."
+        " Addon name will be obtained from there to run tests",
+        "mode": "Mode in which tests run. Options: ['init'(default), 'update']",
     },
 )
-def test(c, modules="base", debugpy=False, logs=True):
+def test(c, modules=None, debugpy=False, cur_file=None, mode="init"):
     """Run Odoo tests
+
+    By default, tests addon from directory being worked on,
+    unless other options are specified.
+
     NOTE: Odoo must be restarted manually after this to go back to normal mode
     """
+    if not modules:
+        cur_module = _get_cwd_addon(cur_file or Path.cwd())
+        if not cur_module:
+            raise exceptions.ParseError(
+                message="You must provide at least one option for modules/file. "
+                "See --help for details."
+            )
+        else:
+            modules = cur_module
     tmp_docker_compose_file = tempfile.NamedTemporaryFile(
-        dir=PROJECT_ROOT, mode="w", suffix=".yaml"
+        mode="w",
+        suffix=".yaml",
     )
     cmd = (
         "docker-compose -f docker-compose.yml "
         f"-f {tmp_docker_compose_file.name} up -d"
     )
-    odoo_command = f"addons init -tw {modules}"
-    _override_docker_command(c, "odoo", odoo_command, file=tmp_docker_compose_file)
+    odoo_command = ["odoo", "--test-enable"]
+    if mode == "init":
+        odoo_command.append("-i")
+    elif mode == "update":
+        odoo_command.append("-u")
+    else:
+        raise exceptions.ParseError(
+            message="Available modes are 'init' or 'update'. See --help for details."
+        )
+    odoo_command.extend([modules, "--stop-after-init", "--workers=0"])
+    _override_docker_command(
+        c,
+        "odoo",
+        odoo_command,
+        file=tmp_docker_compose_file,
+        orig_file=Path(str(PROJECT_ROOT), "docker-compose.yml"),
+    )
     with c.cd(str(PROJECT_ROOT)):
         c.run(
             cmd,
@@ -419,28 +499,9 @@ def test(c, modules="base", debugpy=False, logs=True):
                 DOODBA_DEBUGPY_ENABLE=str(int(debugpy)),
             ),
         )
-        if logs:
-            c.run(
-                "docker-compose logs -f odoo",
-                env=dict(
-                    UID_ENV,
-                ),
-            )
     _logger.info("Waiting for services to spin up...")
     time.sleep(SERVICES_WAIT_TIME)
     tmp_docker_compose_file.close()
-
-
-def _override_docker_command(c, service, command, file=None):
-    docker_config = {
-        "version": "2.4",  # TODO: Update this if main file is updated
-        "services": {service: {"command": command.split(" ")}},
-    }
-    docker_config_yaml = yaml.dump(docker_config)
-    if file:
-        file.write(docker_config_yaml)
-        file.flush()
-    return docker_config_yaml
 
 
 @task(

--- a/tasks.py.jinja
+++ b/tasks.py.jinja
@@ -33,7 +33,7 @@ def _override_docker_command(service, command, file, orig_file=None):
     # Read config from main file
     if orig_file:
         with open(orig_file, "r") as fd:
-            orig_docker_config = yaml.load(fd.read())
+            orig_docker_config = yaml.safe_load(fd.read())
             docker_compose_file_version = orig_docker_config.get("version")
     else:
         docker_compose_file_version = "2.4"
@@ -48,10 +48,14 @@ def _override_docker_command(service, command, file, orig_file=None):
 
 def _remove_auto_reload(file, orig_file):
     with open(orig_file, "r") as fd:
-        orig_docker_config = yaml.load(fd.read())
+        orig_docker_config = yaml.safe_load(fd.read())
     odoo_command = orig_docker_config["services"]["odoo"]["command"]
-    odoo_command[-1] = odoo_command[-1].replace("reload,", "")
-    _override_docker_command("odoo", odoo_command, file, orig_file=orig_file)
+    new_odoo_command = []
+    for flag in odoo_command:
+        if flag.startswith("--dev"):
+            flag = flag.replace("reload,", "")
+        new_odoo_command.append(flag)
+    _override_docker_command("odoo", new_odoo_command, file, orig_file=orig_file)
 
 
 def _get_cwd_addon(file):
@@ -388,26 +392,26 @@ def lint(c, verbose=False):
 def start(c, detach=True, debugpy=False):
     """Start environment."""
     cmd = "docker-compose up"
-    if debugpy:
-        # Remove auto-reload
-        tmp_docker_compose_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".yaml",
-        )
-        cmd = (
-            "docker-compose -f docker-compose.yml "
-            f"-f {tmp_docker_compose_file.name} up"
-        )
-        _remove_auto_reload(
-            tmp_docker_compose_file,
-            orig_file=Path(str(PROJECT_ROOT), "docker-compose.yml"),
-        )
-    if detach:
-        cmd += " --detach"
-    with c.cd(str(PROJECT_ROOT)):
-        c.run(cmd, env=dict(UID_ENV, DOODBA_DEBUGPY_ENABLE=str(int(debugpy))))
-    _logger.info("Waiting for services to spin up...")
-    time.sleep(SERVICES_WAIT_TIME)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".yaml",
+    ) as  tmp_docker_compose_file:
+        if debugpy:
+            # Remove auto-reload
+            cmd = (
+                "docker-compose -f docker-compose.yml "
+                f"-f {tmp_docker_compose_file.name} up"
+            )
+            _remove_auto_reload(
+                tmp_docker_compose_file,
+                orig_file=PROJECT_ROOT / "docker-compose.yml",
+            )
+        if detach:
+            cmd += " --detach"
+        with c.cd(str(PROJECT_ROOT)):
+            c.run(cmd, env=dict(UID_ENV, DOODBA_DEBUGPY_ENABLE=str(int(debugpy))))
+        _logger.info("Waiting for services to spin up...")
+        time.sleep(SERVICES_WAIT_TIME)
 
 
 @task(
@@ -480,41 +484,46 @@ def test(c, modules=None, debugpy=False, cur_file=None, mode="init"):
             )
         else:
             modules = cur_module
-    tmp_docker_compose_file = tempfile.NamedTemporaryFile(
+    with tempfile.NamedTemporaryFile(
         mode="w",
-        suffix=".yaml",
-    )
-    cmd = (
-        "docker-compose -f docker-compose.yml "
-        f"-f {tmp_docker_compose_file.name} up -d"
-    )
-    odoo_command = ["odoo", "--test-enable"]
-    if mode == "init":
-        odoo_command.append("-i")
-    elif mode == "update":
-        odoo_command.append("-u")
-    else:
-        raise exceptions.ParseError(
-            message="Available modes are 'init' or 'update'. See --help for details."
+        suffix=".yaml"
+    ) as tmp_docker_compose_file:
+        cmd = (
+            "docker-compose -f docker-compose.yml "
+            f"-f {tmp_docker_compose_file.name} up -d"
         )
-    odoo_command.extend([modules, "--stop-after-init", "--workers=0"])
-    _override_docker_command(
-        "odoo",
-        odoo_command,
-        file=tmp_docker_compose_file,
-        orig_file=Path(str(PROJECT_ROOT), "docker-compose.yml"),
-    )
-    with c.cd(str(PROJECT_ROOT)):
-        c.run(
-            cmd,
-            env=dict(
-                UID_ENV,
-                DOODBA_DEBUGPY_ENABLE=str(int(debugpy)),
-            ),
+        odoo_command = [
+            "odoo",
+            "--test-enable",
+            "--stop-after-init",
+            "--workers=0"
+        ]
+        if mode == "init":
+            odoo_command.append("-i")
+        elif mode == "update":
+            odoo_command.append("-u")
+        else:
+            raise exceptions.ParseError(
+                message="Available modes are 'init' or 'update'."
+                " See --help for details."
+            )
+        odoo_command.append(modules)
+        _override_docker_command(
+            "odoo",
+            odoo_command,
+            file=tmp_docker_compose_file,
+            orig_file=Path(str(PROJECT_ROOT), "docker-compose.yml"),
         )
-    _logger.info("Waiting for services to spin up...")
-    time.sleep(SERVICES_WAIT_TIME)
-    tmp_docker_compose_file.close()
+        with c.cd(str(PROJECT_ROOT)):
+            c.run(
+                cmd,
+                env=dict(
+                    UID_ENV,
+                    DOODBA_DEBUGPY_ENABLE=str(int(debugpy)),
+                ),
+            )
+        _logger.info("Waiting for services to spin up...")
+        time.sleep(SERVICES_WAIT_TIME)
 
 
 @task(

--- a/tasks.py.jinja
+++ b/tasks.py.jinja
@@ -582,9 +582,11 @@ def restart(c, quick=True):
 
 
 @task(develop)
-def logs(c, tail=10):
+def logs(c, tail=10, follow=True):
     """Obtain last logs of current environment."""
-    cmd = "docker-compose logs -f"
+    cmd = "docker-compose logs"
+    if follow:
+        cmd += " -f"
     if tail:
         cmd += f" --tail {tail}"
     with c.cd(str(PROJECT_ROOT)):

--- a/tasks.py.jinja
+++ b/tasks.py.jinja
@@ -388,6 +388,20 @@ def lint(c, verbose=False):
 def start(c, detach=True, debugpy=False):
     """Start environment."""
     cmd = "docker-compose up"
+    if debugpy:
+        # Remove auto-reload
+        tmp_docker_compose_file = tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".yaml",
+        )
+        cmd = (
+            "docker-compose -f docker-compose.yml "
+            f"-f {tmp_docker_compose_file.name} up"
+        )
+        _remove_auto_reload(
+            tmp_docker_compose_file,
+            orig_file=Path(str(PROJECT_ROOT), "docker-compose.yml"),
+        )
     if detach:
         cmd += " --detach"
     with c.cd(str(PROJECT_ROOT)):
@@ -485,7 +499,6 @@ def test(c, modules=None, debugpy=False, cur_file=None, mode="init"):
         )
     odoo_command.extend([modules, "--stop-after-init", "--workers=0"])
     _override_docker_command(
-        c,
         "odoo",
         odoo_command,
         file=tmp_docker_compose_file,

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 usefixtures = versionless_odoo_autoskip
 addopts = -ra
+markers =
+    sequential: marks tests that cannot run in parallel (deselect with '-m "not sequential"')

--- a/tests/test_tasks_downstream.py
+++ b/tests/test_tasks_downstream.py
@@ -1,3 +1,4 @@
+import time
 from pathlib import Path
 
 import pytest
@@ -22,6 +23,16 @@ def _install_status(module, dbname="devel"):
         "-tc",
         f"select state from ir_module_module where name='{module}'",
     ).strip()
+
+
+def _wait_for_test_to_start():
+    # Wait for test to start
+    for _i in range(10):
+        time.sleep(2)
+        _ret_code, stdout, _stderr = docker_compose.run(("logs", "odoo"))
+        if "Executing odoo --test-enable" in stdout:
+            break
+    return stdout
 
 
 def test_resetdb(
@@ -128,6 +139,116 @@ def test_start(
             invoke("stop")
             stdout = invoke("start", "--debugpy")
             assert socket_is_open("127.0.0.1", int(supported_odoo_version) * 1000 + 899)
+            # Check if auto-reload is disabled
+            container_logs = docker_compose("logs", "odoo")
+            assert "dev=reload" not in container_logs
+    finally:
+        # Imagine the user is in the odoo subrepo for this command
+        with local.cwd(tmp_path / "odoo" / "custom" / "src" / "odoo"):
+            invoke("stop", "--purge")
+
+
+@pytest.mark.sequential
+def test_install(
+    cloned_template: Path,
+    docker: LocalCommand,
+    supported_odoo_version: float,
+    tmp_path: Path,
+):
+    """Test the install task.
+
+    On this test flow, other downsream tasks are also tested:
+
+    - img-build
+    - git-aggregate
+    - stop --purge
+    """
+    try:
+        with local.cwd(tmp_path):
+            copy(
+                src_path=str(cloned_template),
+                vcs_ref="HEAD",
+                force=True,
+                data={"odoo_version": supported_odoo_version},
+            )
+            # Imagine the user is in the src subfolder for these tasks
+            # and the DB is clean
+            with local.cwd(tmp_path / "odoo" / "custom" / "src"):
+                invoke("img-build")
+                invoke("git-aggregate")
+                invoke("resetdb")
+            # Install "purchase"
+            ret_code, stdout, stderr = invoke.run(("install", "-m", "purchase"))
+            assert "Executing odoo --stop-after-init --init purchase" in stderr
+            assert _install_status("purchase") == "installed"
+            assert _install_status("sale") == "uninstalled"
+            # Change to "sale" subfolder and install
+            with local.cwd(
+                tmp_path / "odoo" / "custom" / "src" / "odoo" / "addons" / "sale"
+            ):
+                # Install "sale"
+                ret_code, stdout, stderr = invoke.run("install")
+                assert "Executing odoo --stop-after-init --init sale" in stderr
+                assert _install_status("purchase") == "installed"
+                assert _install_status("sale") == "installed"
+    finally:
+        # Imagine the user is in the odoo subrepo for this command
+        with local.cwd(tmp_path / "odoo" / "custom" / "src" / "odoo"):
+            invoke("stop", "--purge")
+
+
+@pytest.mark.sequential
+def test_test(
+    cloned_template: Path,
+    docker: LocalCommand,
+    supported_odoo_version: float,
+    tmp_path: Path,
+):
+    """Test the test task.
+
+    On this test flow, other downsream tasks are also tested:
+
+    - img-build
+    - git-aggregate
+    - stop --purge
+    """
+    try:
+        with local.cwd(tmp_path):
+            copy(
+                src_path=str(cloned_template),
+                vcs_ref="HEAD",
+                force=True,
+                data={"odoo_version": supported_odoo_version},
+            )
+            # Imagine the user is in the src subfolder for these tasks
+            with local.cwd(tmp_path / "odoo" / "custom" / "src"):
+                invoke("img-build")
+                invoke("git-aggregate")
+                invoke("resetdb")
+            # This should test just "purchase"
+            invoke("test", "-m", "purchase")
+            stdout = _wait_for_test_to_start()
+            assert (
+                "Executing odoo --test-enable --stop-after-init --workers=0 -i purchase"
+                in stdout
+            )
+            # Change to "sale" subfolder and test
+            with local.cwd(
+                tmp_path / "odoo" / "custom" / "src" / "odoo" / "addons" / "sale"
+            ):
+                # Test "sale"
+                invoke("test")
+                stdout = _wait_for_test_to_start()
+                assert (
+                    "Executing odoo --test-enable --stop-after-init --workers=0 -i sale"
+                    in stdout
+                )
+            # Test "--debugpy and wait time call
+            invoke("stop")
+            invoke("test", "-m", "sale", "--debugpy")
+            assert socket_is_open("127.0.0.1", int(supported_odoo_version) * 1000 + 899)
+            stdout = _wait_for_test_to_start()
+            assert "python -m debugpy" in stdout
     finally:
         # Imagine the user is in the odoo subrepo for this command
         with local.cwd(tmp_path / "odoo" / "custom" / "src" / "odoo"):


### PR DESCRIPTION
1. Add invoke task to easily run Odoo tests. It accepts both the name of the module(s) to test, or it can detect the module you are currently working on if you pass a working directory or file. It also allows to run the tests in debug mode.
2. Add VSCode tasks that match invoke task and respective options. A normal task automatically passes to invoke the file you are working on.
3. Add VSCode debug configurations for debugging Odoo tests.
4. Add invoke task to easily install Odoo modules. You can pass the name(s), or also `--core`, `--extra` or `--private` options to install everyting.

It would also be good to incorporate https://github.com/Tecnativa/doodba-copier-template/pull/139 here, once it is finished.

TT26483