### PR TITLE
Add buttons to run start and stop tasks

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
+    "actboy168.tasks",
     "dbaeumer.vscode-eslint",
     "dchanco.vsc-invoke",
     "EditorConfig.editorconfig",
@@ -11,7 +12,6 @@
     "msjsdiag.debugger-for-chrome",
     "redhat.vscode-xml",
     "samuelcolvin.jinjahtml",
-    "actboy168.tasks",
     "syler.sass-indented"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,6 +11,7 @@
     "msjsdiag.debugger-for-chrome",
     "redhat.vscode-xml",
     "samuelcolvin.jinjahtml",
+    "actboy168.tasks",
     "syler.sass-indented"
   ]
 }

--- a/tasks.py.jinja
+++ b/tasks.py.jinja
@@ -171,6 +171,11 @@ def write_code_workspace_file(c, cw_path=None):
                     "clear": False,
                 },
                 "problemMatcher": [],
+                "options": {"statusbar": {
+                    "label": "$(play-circle)",
+                    "color": "#065535"
+                    }
+                },
             },
             {
                 "label": "Start Odoo in debug mode",
@@ -186,6 +191,7 @@ def write_code_workspace_file(c, cw_path=None):
                     "clear": False,
                 },
                 "problemMatcher": [],
+                "options": {"statusbar": {"hide": True}},
             },
             {
                 "label": "Stop Odoo",
@@ -201,6 +207,11 @@ def write_code_workspace_file(c, cw_path=None):
                     "clear": False,
                 },
                 "problemMatcher": [],
+                "options": {"statusbar": {
+                    "label": "$(stop-circle)",
+                    "color": "#9A0000"
+                    }
+                },
             },
         ],
     }


### PR DESCRIPTION
Add [Tasks extension](https://marketplace.visualstudio.com/items?itemName=actboy168.tasks) to allow launching Start and Stop Odoo tasks from the bottom tasks bar. 

I've added it with some icons and color, but we can also leave them blank and add some text to describe. 