### PR TITLE
Migrate from prettier/prettier to prettier/pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,11 +34,8 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear==20.1.4]
-  # TODO Migrate to new prettier pre-commit repo after fixed:
-  # HACK https://github.com/prettier/pre-commit/pull/17
-  # HACK https://github.com/prettier/pre-commit/pull/18
-  - repo: https://github.com/prettier/prettier
-    rev: 2.1.2
+  - repo: https://github.com/prettier/pre-commit
+    rev: v2.1.2
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -35,15 +35,15 @@ repos:
         name: isort except __init__.py
         args: [--settings, .]
         exclude: /__init__\.py$
-  # TODO Migrate to new prettier pre-commit repo after fixed:
-  # HACK https://github.com/prettier/pre-commit/pull/17
-  # HACK https://github.com/prettier/pre-commit/pull/18
-  - repo: https://github.com/prettier/prettier
-    rev: 2.1.2
+  - repo: https://github.com/prettier/pre-commit
+    rev: v2.1.2
     hooks:
       - id: prettier
         name: prettier + plugin-xml
         additional_dependencies:
+          # TODO: Remove this when https://github.com/prettier/pre-commit/pull/18
+          # or similar is fixed
+          - prettier@2.1.2
           - "@prettier/plugin-xml@0.12.0"
         args:
           - --plugin=@prettier/plugin-xml

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -41,8 +41,7 @@ repos:
       - id: prettier
         name: prettier + plugin-xml
         additional_dependencies:
-          # TODO: Remove this when https://github.com/prettier/pre-commit/pull/18
-          # or similar is fixed
+          # HACK https://github.com/prettier/pre-commit/issues/16#issuecomment-713474520
           - prettier@2.1.2
           - "@prettier/plugin-xml@0.12.0"
         args:


### PR DESCRIPTION
We are starting to get https://github.com/pre-commit/pre-commit/issues/1674 and similar errors. Seems like we need to migrate to `prettier/pre-commit` after all... This applies a similar fix to https://github.com/OCA/oca-addons-repo-template/pull/38. See there for details.

* Revert "Pin nodejs versions for pre-commit"
  This reverts commit 955f6ddfcf98fbfadc9aa257cb8652813eb6337c.

* Re-apply "Migrate prettier from prettier/prettier to prettier/pre-commit"
  This reverts commit 1f851935d09963d9ae4138be0ba5d038c4735382.

* Improve prettier pre-commit configuration
  After https://github.com/prettier/pre-commit/pull/17 was fixed

* Update to v2.1.2 in template config