### PR TITLE
Explain how to avoid the prettiermageddon when updating

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,6 +28,7 @@ Maybe not so frequent, but interesting anyway. 🤷
 - [Why do I get a "Connection Refused" error when trying to lauch the VSCode Chrome JS Debugger?](#why-do-i-get-a-connection-refused-error-when-trying-to-lauch-the-vscode-chrome-js-debugger)
 - [Why can't Firefox load the page after I start a debugging session?](#why-cant-firefox-load-the-page-after-i-start-a-debugging-session)
 - [Why won't my program stop on the specified breakpoints when using Firefox?](#why-wont-my-program-stop-on-the-specified-breakpoints-when-using-firefox)
+- [When upgrading from an old template, prettier fails badly. How to update?](#when-upgrading-from-an-old-template-prettier-fails-badly-how-to-update)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- prettier-ignore-end -->
@@ -540,3 +541,38 @@ correct URL. However, if you need to log in, you loose that URL. To avoid that, 
 sure you are not losing your cookies each time you reload a debugging session. (See
 [Why don't I see my Firefox extensions while debugging?](#Why-don't-I-see-my-Firefox-extensions-while-debugging?)
 for how to set up your Firefox debugging profile)
+
+## When upgrading from an old template, prettier fails badly. How to update?
+
+Whether it was prettier, npm, nodejs or whoever else, the fact is that
+[recently there happened a prettiermageddon](https://github.com/prettier/prettier/issues/9459).
+
+When you're updating from an older template to a newer, Copier will try to produce a
+vanilla project with the old template before updating it, to be able to extract a smart
+diff and apply the required changes to your subproject.
+
+Since old versions of the template are broken due to this prettier problem, you cannot
+update anymore. Well, here's the workaround:
+
+1.  Indicate to [nodeenv](http://ekalinin.github.io/nodeenv/) that your default nodejs
+    version is 14.14.0 by creating a file in `~/.nodeenvrc` with the following contents.
+    This will avoid the problem of prettier being unable to install:
+
+    ```ini
+    [nodeenv]
+    node = 14.14.0
+    ```
+
+1.  Update to latest template
+    [skipping `prettier` hook](https://pre-commit.com/#temporarily-disabling-hooks).
+    This will avoid the problem of prettier + plugin-xml being unable to execute, even
+    if properly installed:
+
+    ```bash
+    env SKIP=prettier copier update
+    ```
+
+Once all your doodba subprojects are on template v2.5.0 or later, you won't need the
+`~/.nodeenvrc` anymore (hopefully) and you can safely delete it, as node version is
+pinned there and we install prettier from
+[their new specific pre-commit repo](https://github.com/prettier/pre-commit).


### PR DESCRIPTION
Recently prettier got broken badly (see https://github.com/prettier/prettier/issues/9459 and all the related PRs/issues there).

This explains how to avoid that problem when updating templates.

To know if this is the problem you're facing, this is the log that you'd find if you cannot install prettier due to this problem:

<details>

```
plumbum.commands.processes.ProcessExecutionError: Unexpected exit code: 1
Command line: | /usr/bin/git commit --allow-empty -am 'dumb commit 2'
Stderr:       | [INFO] Installing environment for https://github.com/prettier/prettier.
              | [INFO] Once installed this environment will be reused.
              | [INFO] This may take a few minutes...
              | An unexpected error has occurred: CalledProcessError: command: ('/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/bin/node', '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/bin/npm', 'install', '--dev', '--prod', '--ignore-prepublish', '--no-progress', '--no-save')
              | return code: 1
              | expected return code: 0
              | stdout: (none)
              | stderr:
              |     npm WARN install Usage of the `--dev` option is deprecated. Use `--include=dev` instead.
              |     npm ERR! code ERESOLVE
              |     npm ERR! ERESOLVE unable to resolve dependency tree
              |     npm ERR! 
              |     npm ERR! While resolving: prettier@2.1.2
              |     npm ERR! Found: remark-parse@8.0.3
              |     npm ERR! node_modules/remark-parse
              |     npm ERR!   remark-parse@"8.0.3" from the root project
              |     npm ERR! 
              |     npm ERR! Could not resolve dependency:
              |     npm ERR! peer remark-parse@"^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0" from remark-math@1.0.6
              |     npm ERR! node_modules/remark-math
              |     npm ERR!   remark-math@"1.0.6" from the root project
              |     npm ERR! 
              |     npm ERR! Fix the upstream dependency conflict, or retry
              |     npm ERR! this command with --force, or --legacy-peer-deps
              |     npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
              |     npm ERR! 
              |     npm ERR! See /var/home/yajo/.npm/eresolve-report.txt for a full report.
              |     
              |     npm ERR! A complete log of this run can be found in:
              |     npm ERR!     /var/home/yajo/.npm/_logs/2020-11-09T10_46_07_724Z-debug.log
              |     
              | Check the log at /var/home/yajo/.cache/pre-commit/pre-commit.log
```

</details>

Also, this is the log when executing prettier (after it is installed) in an environment that is also affected by this problem:

<details>

```
Inicializado repositorio Git vacío en /tmp/copier.main.update_diff.7jsj3arb/.git/
pre-commit installed at .git/hooks/pre-commit
Traceback (most recent call last):
  File "/var/home/yajo/.local/bin/copier", line 8, in <module>
    sys.exit(CopierApp.run())
  File "/var/home/yajo/.local/pipx/venvs/copier/lib64/python3.9/site-packages/plumbum/cli/application.py", line 577, in run
    inst, retcode = subapp.run(argv, exit=False)
  File "/var/home/yajo/.local/pipx/venvs/copier/lib64/python3.9/site-packages/plumbum/cli/application.py", line 572, in run
    retcode = inst.main(*tailargs)
  File "/var/home/yajo/.local/pipx/venvs/copier/lib64/python3.9/site-packages/copier/cli.py", line 38, in _wrapper
    return method(*args, **kwargs)
  File "/var/home/yajo/.local/pipx/venvs/copier/lib64/python3.9/site-packages/copier/cli.py", line 306, in main
    self.parent._copy(
  File "/var/home/yajo/.local/pipx/venvs/copier/lib64/python3.9/site-packages/copier/cli.py", line 174, in _copy
    return copy(
  File "/var/home/yajo/.local/pipx/venvs/copier/lib64/python3.9/site-packages/copier/main.py", line 148, in copy
    update_diff(conf=conf)
  File "/var/home/yajo/.local/pipx/venvs/copier/lib64/python3.9/site-packages/copier/main.py", line 267, in update_diff
    git("commit", "--allow-empty", "-am", "dumb commit 2")
  File "/var/home/yajo/.local/pipx/venvs/copier/lib64/python3.9/site-packages/plumbum/commands/base.py", line 96, in __call__
    return self.run(args, **kwargs)[1]
  File "/var/home/yajo/.local/pipx/venvs/copier/lib64/python3.9/site-packages/plumbum/commands/base.py", line 232, in run
    return p.run()
  File "/var/home/yajo/.local/pipx/venvs/copier/lib64/python3.9/site-packages/plumbum/commands/base.py", line 193, in runner
    return run_proc(p, retcode, timeout)
  File "/var/home/yajo/.local/pipx/venvs/copier/lib64/python3.9/site-packages/plumbum/commands/processes.py", line 302, in run_proc
    return _check_process(proc, retcode, timeout, stdout, stderr)
  File "/var/home/yajo/.local/pipx/venvs/copier/lib64/python3.9/site-packages/plumbum/commands/processes.py", line 22, in _check_process
    proc.verify(retcode, timeout, stdout, stderr)
  File "/var/home/yajo/.local/pipx/venvs/copier/lib64/python3.9/site-packages/plumbum/machines/base.py", line 24, in verify
    raise ProcessExecutionError(
plumbum.commands.processes.ProcessExecutionError: Unexpected exit code: 1
Command line: | /usr/bin/git commit --allow-empty -am 'dumb commit 2'
Stderr:       | forbidden files......................................(no files to check)Skipped
              | black....................................................................Passed
              | pyupgrade................................................................Passed
              | isort except __init__.py.................................................Passed
              | prettier + plugin-xml....................................................Failed
              | - hook id: prettier
              | - exit code: 1
              | 
              | internal/modules/cjs/loader.js:883
              |   throw err;
              |   ^
              | 
              | Error: Cannot find module 'prettier/doc'
              | Require stack:
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js
              |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
              |     at Function.Module._load (internal/modules/cjs/loader.js:725:27)
              |     at Module.require (internal/modules/cjs/loader.js:952:19)
              |     at require (internal/modules/cjs/helpers.js:88:18)
              |     at Object.<anonymous> (/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js:1:29)
              |     at Module._compile (internal/modules/cjs/loader.js:1063:30)
              |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
              |     at Module.load (internal/modules/cjs/loader.js:928:32)
              |     at Function.Module._load (internal/modules/cjs/loader.js:769:14)
              |     at Module.require (internal/modules/cjs/loader.js:952:19) {
              |   code: 'MODULE_NOT_FOUND',
              |   requireStack: [
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js'
              |   ]
              | }
              | internal/modules/cjs/loader.js:883
              |   throw err;
              |   ^
              | 
              | Error: Cannot find module 'prettier/doc'
              | Require stack:
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js
              |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
              |     at Function.Module._load (internal/modules/cjs/loader.js:725:27)
              |     at Module.require (internal/modules/cjs/loader.js:952:19)
              |     at require (internal/modules/cjs/helpers.js:88:18)
              |     at Object.<anonymous> (/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js:1:29)
              |     at Module._compile (internal/modules/cjs/loader.js:1063:30)
              |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
              |     at Module.load (internal/modules/cjs/loader.js:928:32)
              |     at Function.Module._load (internal/modules/cjs/loader.js:769:14)
              |     at Module.require (internal/modules/cjs/loader.js:952:19) {
              |   code: 'MODULE_NOT_FOUND',
              |   requireStack: [
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js'
              |   ]
              | }
              | internal/modules/cjs/loader.js:883
              |   throw err;
              |   ^
              | 
              | Error: Cannot find module 'prettier/doc'
              | Require stack:
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js
              |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
              |     at Function.Module._load (internal/modules/cjs/loader.js:725:27)
              |     at Module.require (internal/modules/cjs/loader.js:952:19)
              |     at require (internal/modules/cjs/helpers.js:88:18)
              |     at Object.<anonymous> (/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js:1:29)
              |     at Module._compile (internal/modules/cjs/loader.js:1063:30)
              |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
              |     at Module.load (internal/modules/cjs/loader.js:928:32)
              |     at Function.Module._load (internal/modules/cjs/loader.js:769:14)
              |     at Module.require (internal/modules/cjs/loader.js:952:19) {
              |   code: 'MODULE_NOT_FOUND',
              |   requireStack: [
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js'
              |   ]
              | }
              | internal/modules/cjs/loader.js:883
              |   throw err;
              |   ^
              | 
              | Error: Cannot find module 'prettier/doc'
              | Require stack:
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js
              |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
              |     at Function.Module._load (internal/modules/cjs/loader.js:725:27)
              |     at Module.require (internal/modules/cjs/loader.js:952:19)
              |     at require (internal/modules/cjs/helpers.js:88:18)
              |     at Object.<anonymous> (/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js:1:29)
              |     at Module._compile (internal/modules/cjs/loader.js:1063:30)
              |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
              |     at Module.load (internal/modules/cjs/loader.js:928:32)
              |     at Function.Module._load (internal/modules/cjs/loader.js:769:14)
              |     at Module.require (internal/modules/cjs/loader.js:952:19) {
              |   code: 'MODULE_NOT_FOUND',
              |   requireStack: [
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js'
              |   ]
              | }
              | internal/modules/cjs/loader.js:883
              |   throw err;
              |   ^
              | 
              | Error: Cannot find module 'prettier/doc'
              | Require stack:
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js
              |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
              |     at Function.Module._load (internal/modules/cjs/loader.js:725:27)
              |     at Module.require (internal/modules/cjs/loader.js:952:19)
              |     at require (internal/modules/cjs/helpers.js:88:18)
              |     at Object.<anonymous> (/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js:1:29)
              |     at Module._compile (internal/modules/cjs/loader.js:1063:30)
              |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
              |     at Module.load (internal/modules/cjs/loader.js:928:32)
              |     at Function.Module._load (internal/modules/cjs/loader.js:769:14)
              |     at Module.require (internal/modules/cjs/loader.js:952:19) {
              |   code: 'MODULE_NOT_FOUND',
              |   requireStack: [
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js'
              |   ]
              | }
              | internal/modules/cjs/loader.js:883
              |   throw err;
              |   ^
              | 
              | Error: Cannot find module 'prettier/doc'
              | Require stack:
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js
              |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
              |     at Function.Module._load (internal/modules/cjs/loader.js:725:27)
              |     at Module.require (internal/modules/cjs/loader.js:952:19)
              |     at require (internal/modules/cjs/helpers.js:88:18)
              |     at Object.<anonymous> (/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js:1:29)
              |     at Module._compile (internal/modules/cjs/loader.js:1063:30)
              |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
              |     at Module.load (internal/modules/cjs/loader.js:928:32)
              |     at Function.Module._load (internal/modules/cjs/loader.js:769:14)
              |     at Module.require (internal/modules/cjs/loader.js:952:19) {
              |   code: 'MODULE_NOT_FOUND',
              |   requireStack: [
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js'
              |   ]
              | }
              | internal/modules/cjs/loader.js:883
              |   throw err;
              |   ^
              | 
              | Error: Cannot find module 'prettier/doc'
              | Require stack:
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js
              |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
              |     at Function.Module._load (internal/modules/cjs/loader.js:725:27)
              |     at Module.require (internal/modules/cjs/loader.js:952:19)
              |     at require (internal/modules/cjs/helpers.js:88:18)
              |     at Object.<anonymous> (/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js:1:29)
              |     at Module._compile (internal/modules/cjs/loader.js:1063:30)
              |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
              |     at Module.load (internal/modules/cjs/loader.js:928:32)
              |     at Function.Module._load (internal/modules/cjs/loader.js:769:14)
              |     at Module.require (internal/modules/cjs/loader.js:952:19) {
              |   code: 'MODULE_NOT_FOUND',
              |   requireStack: [
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js'
              |   ]
              | }
              | internal/modules/cjs/loader.js:883
              |   throw err;
              |   ^
              | 
              | Error: Cannot find module 'prettier/doc'
              | Require stack:
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js
              |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
              |     at Function.Module._load (internal/modules/cjs/loader.js:725:27)
              |     at Module.require (internal/modules/cjs/loader.js:952:19)
              |     at require (internal/modules/cjs/helpers.js:88:18)
              |     at Object.<anonymous> (/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js:1:29)
              |     at Module._compile (internal/modules/cjs/loader.js:1063:30)
              |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
              |     at Module.load (internal/modules/cjs/loader.js:928:32)
              |     at Function.Module._load (internal/modules/cjs/loader.js:769:14)
              |     at Module.require (internal/modules/cjs/loader.js:952:19) {
              |   code: 'MODULE_NOT_FOUND',
              |   requireStack: [
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js'
              |   ]
              | }
              | internal/modules/cjs/loader.js:883
              |   throw err;
              |   ^
              | 
              | Error: Cannot find module 'prettier/doc'
              | Require stack:
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js
              | - /var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js
              |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
              |     at Function.Module._load (internal/modules/cjs/loader.js:725:27)
              |     at Module.require (internal/modules/cjs/loader.js:952:19)
              |     at require (internal/modules/cjs/helpers.js:88:18)
              |     at Object.<anonymous> (/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js:1:29)
              |     at Module._compile (internal/modules/cjs/loader.js:1063:30)
              |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
              |     at Module.load (internal/modules/cjs/loader.js:928:32)
              |     at Function.Module._load (internal/modules/cjs/loader.js:769:14)
              |     at Module.require (internal/modules/cjs/loader.js:952:19) {
              |   code: 'MODULE_NOT_FOUND',
              |   requireStack: [
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/embed.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/@prettier/plugin-xml/src/plugin.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/common/load-plugins.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/src/cli/index.js',
              |     '/var/home/yajo/.cache/pre-commit/repow9n8yvh_/node_env-default/lib/node_modules/prettier/bin/prettier.js'
              |   ]
              | }
              | 
              | Trim Trailing Whitespace.................................................Passed
              | Fix End of Files.........................................................Passed
              | Debug Statements (Python)................................................Passed
              | Fix python encoding pragma...............................................Passed
              | Check for case conflicts.................................................Passed
              | Check docstring is first.................................................Passed
              | Check that executables have shebangs.................(no files to check)Skipped
              | Check for merge conflicts................................................Passed
              | Check for broken symlinks............................(no files to check)Skipped
              | Check Xml............................................(no files to check)Skipped
              | Mixed line ending........................................................Passed
              | flake8 except __init__.py................................................Passed
              | flake8 only __init__.py..............................(no files to check)Skipped
              | pylint with optional checks..............................................Passed
              | - hook id: pylint
              | - duration: 1.28s
              | pylint with mandatory checks.............................................Passed
              | eslint...............................................(no files to check)Skipped
              | - hook id: eslint
```

</details>

@Tecnativa TT26674