### PR TITLE
Move search.followSymlinks to workspace setting

### DIFF
--- a/.vscode/settings.json.jinja
+++ b/.vscode/settings.json.jinja
@@ -12,7 +12,6 @@
   ],
   "python.linting.pylintEnabled": true,
   "restructuredtext.confPath": "",
-  "search.followSymlinks": false,
   "search.useIgnoreFiles": false,
 
   // Language-specific configurations

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -106,6 +106,9 @@ def write_code_workspace_file(c, cw_path=None):
             cw_config = json.load(cw_fd)
     except (FileNotFoundError, json.decoder.JSONDecodeError):
         pass  # Nevermind, we start with a new config
+    # Static settings
+    cw_config.setdefault("settings", {})
+    cw_config["settings"].update({"search.followSymlinks": False})
     # Launch configurations
     debugpy_configuration = {
         "name": "Attach Python debugger to running container",


### PR DESCRIPTION
It turns out this setting is ignored if set as folder setting.