### PR TITLE
Add restart options to reload environment

### DIFF
--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -315,6 +315,22 @@ def write_code_workspace_file(c, cw_path=None):
                 "problemMatcher": [],
                 "options": {"statusbar": {"label": "$(stop-circle) Stop Odoo"}},
             },
+            {
+                "label": "Restart Odoo",
+                "type": "process",
+                "command": "invoke",
+                "args": ["restart"],
+                "presentation": {
+                    "echo": True,
+                    "reveal": "silent",
+                    "focus": False,
+                    "panel": "shared",
+                    "showReuseMessage": True,
+                    "clear": False,
+                },
+                "problemMatcher": [],
+                "options": {"statusbar": {"label": "$(history) Restart Odoo"}},
+            },
         ],
     }
     # Sort project folders
@@ -416,7 +432,16 @@ def start(c, detach=True, debugpy=False):
         if detach:
             cmd += " --detach"
         with c.cd(str(PROJECT_ROOT)):
-            c.run(cmd, env=dict(UID_ENV, DOODBA_DEBUGPY_ENABLE=str(int(debugpy))))
+            result = c.run(
+                cmd,
+                pty=True,
+                env=dict(
+                    UID_ENV,
+                    DOODBA_DEBUGPY_ENABLE=str(int(debugpy)),
+                ),
+            )
+            if not ("Recreating" in result.stdout or "Starting" in result.stdout):
+                restart(c)
         _logger.info("Waiting for services to spin up...")
         time.sleep(SERVICES_WAIT_TIME)
 


### PR DESCRIPTION
After auto-reload as been removed, it is more difficult to debug when making regular changes. Start task does not recreate Odoo container, so no changes are reflected.

This ensures Odoo is recreated after every start command.
It also adds a VSCode task and button to easily restart Odoo and the proxy.

It would be nice to do it automatically when you press the "Restart" button in the VSCode debugger, but AFAICS that only restarts the "Attach" configurations, which will always find the debugger already running, leaving no option but to "Disconnect" and launch again. 
If you press "Restart Odoo", the debugging session is also disconnected and needs to be lauched again.