### PR TITLE
Small fixes and improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear==20.1.4]
-  - repo: https://github.com/prettier/pre-commit
+  - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.1.2
     hooks:
       - id: prettier

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -37,7 +37,7 @@ repos:
         name: isort except __init__.py
         args: [--settings, .]
         exclude: /__init__\.py$
-  - repo: https://github.com/prettier/pre-commit
+  - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.1.2
     hooks:
       - id: prettier

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -155,32 +155,6 @@ def write_code_workspace_file(c, cw_path=None):
                 "preLaunchTask": "Run Odoo Tests in debug mode for current module",
                 "internalConsoleOptions": "openOnSessionStart",
             },
-            {
-                "name": "Start Odoo and debug JS in Firefox",
-                "configurations": ["Connect to firefox debugger"],
-                "preLaunchTask": "Start Odoo",
-            },
-            {
-                "name": "Start Odoo and debug JS in Chrome",
-                "configurations": ["Connect to chrome debugger"],
-                "preLaunchTask": "Start Odoo",
-            },
-            {
-                "name": "Start Odoo and debug Python + JS in Firefox",
-                "configurations": [
-                    "Attach Python debugger to running container",
-                    "Connect to firefox debugger",
-                ],
-                "preLaunchTask": "Start Odoo in debug mode",
-            },
-            {
-                "name": "Start Odoo and debug Python + JS in Chrome",
-                "configurations": [
-                    "Attach Python debugger to running container",
-                    "Connect to chrome debugger",
-                ],
-                "preLaunchTask": "Start Odoo in debug mode",
-            },
         ],
         "configurations": [
             debugpy_configuration,

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -571,13 +571,22 @@ def restart(c, quick=True):
         c.run(cmd, env=UID_ENV)
 
 
-@task(develop)
-def logs(c, tail=10, follow=True):
+@task(
+    develop,
+    help={
+        "container": "Names of the containers from which logs will be obtained."
+        " You can specify a single one, or several comma-separated names."
+        " Default: None (show logs for all containers)"
+    },
+)
+def logs(c, tail=10, follow=True, container=None):
     """Obtain last logs of current environment."""
     cmd = "docker-compose logs"
     if follow:
         cmd += " -f"
     if tail:
         cmd += f" --tail {tail}"
+    if container:
+        cmd += f" {container.replace(',', ' ')}"
     with c.cd(str(PROJECT_ROOT)):
         c.run(cmd)


### PR DESCRIPTION
1. Migrate from prettier/pre-commit to pre-commit/mirrors-prettier (#prettiermageddon 2.0)
2. Simplify VSCode debugger configurations: Remove some tasks, now only having
    - Start Odoo (in debug mode) and debug python
    - Attach to Python debugger
    - Attach to JS debugger using Chromium or Firefox (1 task each)
    - Test and debug current module
