### PR TITLE
Update tests to set env variables through file instead of set-env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,9 +53,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Generate cache key CACHE
         run:
-          echo "::set-env name=CACHE::${{ secrets.CACHE_DATE }} ${{ runner.os }}
-          $(python -VV | sha256sum | cut -d' ' -f1) ${{ hashFiles('pyproject.toml') }}
-          ${{ hashFiles('poetry.lock') }} ${{ hashFiles('.pre-commit-config.yaml') }}"
+          echo "CACHE=${{ secrets.CACHE_DATE }} ${{ runner.os }} $(python -VV |
+          sha256sum | cut -d' ' -f1) ${{ hashFiles('pyproject.toml') }} ${{
+          hashFiles('poetry.lock') }} ${{ hashFiles('.pre-commit-config.yaml') }}" >>
+          $GITHUB_ENV
       - uses: actions/cache@v2.1.0
         with:
           path: |
@@ -65,7 +66,7 @@ jobs:
           key: venv ${{ env.CACHE }}
       - run: pip install poetry
       - name: Patch $PATH
-        run: echo "::set-env name=PATH::$HOME/.local/bin:$PATH"
+        run: echo "PATH=$HOME/.local/bin:$PATH" >> $GITHUB_ENV
       - run: poetry install
       # Precreate shared networks to avoid race conditions
       - run: docker network create inverseproxy_shared

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
           key: venv ${{ env.CACHE }}
       - run: pip install poetry
       - name: Patch $PATH
-        run: echo "PATH=$HOME/.local/bin:$PATH" >> $GITHUB_ENV
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       - run: poetry install
       # Precreate shared networks to avoid race conditions
       - run: docker network create inverseproxy_shared


### PR DESCRIPTION
`set-env` command has been deprecated and disabled: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Suggested alternative is to echo vars to default file: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files