### PR TITLE
workspaceRoot -> workspaceFolder

### DIFF
--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -92,7 +92,7 @@ def write_code_workspace_file(c, cw_path=None):
     Example: `--cw-path doodba.my-custom-name.code-workspace`
     """
     root_name = f"doodba.{PROJECT_ROOT.name}"
-    root_var = "${workspaceRoot:%s}" % root_name
+    root_var = "${workspaceFolder:%s}" % root_name
     if not cw_path:
         try:
             cw_path = next(PROJECT_ROOT.glob("doodba.*.code-workspace"))
@@ -165,7 +165,7 @@ def write_code_workspace_file(c, cw_path=None):
     # Configure folders and debuggers
     debugpy_configuration["pathMappings"].append(
         {
-            "localRoot": "${workspaceRoot:odoo}/",
+            "localRoot": "${workspaceFolder:odoo}/",
             "remoteRoot": "/opt/odoo/custom/src/odoo",
         }
     )
@@ -182,12 +182,12 @@ def write_code_workspace_file(c, cw_path=None):
                 addon / "__openerp__.py"
             ).is_file():
                 if subrepo.name == "odoo":
-                    local_path = "${workspaceRoot:%s}/addons/%s/" % (
+                    local_path = "${workspaceFolder:%s}/addons/%s/" % (
                         subrepo.name,
                         addon.name,
                     )
                 else:
-                    local_path = "${workspaceRoot:%s}/%s" % (subrepo.name, addon.name)
+                    local_path = "${workspaceFolder:%s}/%s" % (subrepo.name, addon.name)
                 debugpy_configuration["pathMappings"].append(
                     {
                         "localRoot": local_path,
@@ -195,7 +195,7 @@ def write_code_workspace_file(c, cw_path=None):
                     }
                 )
                 url = f"http://localhost:{ODOO_VERSION:.0f}069/{addon.name}/static/"
-                path = "${workspaceRoot:%s}/%s/static/" % (
+                path = "${workspaceFolder:%s}/%s/static/" % (
                     subrepo.name,
                     addon.relative_to(subrepo),
                 )

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -116,7 +116,8 @@ def write_code_workspace_file(c, cw_path=None):
         "request": "attach",
         "pathMappings": [],
         "port": int(ODOO_VERSION) * 1000 + 899,
-        "host": "localhost",
+        # HACK https://github.com/microsoft/vscode-python/issues/14820
+        "host": "0.0.0.0",
     }
     firefox_configuration = {
         "type": "firefox",

--- a/tests/test_nitpicking.py
+++ b/tests/test_nitpicking.py
@@ -267,7 +267,7 @@ def test_code_workspace_file(
         ]
         # Firefox debugger configuration
         url = f"http://localhost:{supported_odoo_version:.0f}069/test_module_static/static/"
-        path = "${workspaceRoot:private}/test_module_static/static/"
+        path = "${workspaceFolder:private}/test_module_static/static/"
         firefox_configuration = next(
             conf
             for conf in workspace_definition["launch"]["configurations"]


### PR DESCRIPTION
According to [the docs][1], `${workspaceRoot}` is now deprecated:

![imagen](https://user-images.githubusercontent.com/973709/100211658-4e99a980-2f04-11eb-856c-a2465ccd44ad.png)


[1]: https://code.visualstudio.com/docs/editor/multi-root-workspaces#_debugging