### PR TITLE
Fix pre commit deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,6 @@ repos:
     rev: 5.5.1
     hooks:
       - id: isort
-        additional_dependencies: ["isort[pyproject]"]
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
     hooks:

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -23,7 +23,7 @@ repos:
         language: fail
         files: "\\.rej$"
   - repo: https://github.com/oca/maintainer-tools
-    rev: f1b5595
+    rev: b9c963d
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
@@ -101,7 +101,7 @@ repos:
           - --exit-zero
         verbose: true
         additional_dependencies:
-          - isort==4.3.21
+          - isort==4.3.4
           - pylint-odoo==3.5.0
       - id: pylint
         name: pylint with mandatory checks
@@ -109,7 +109,7 @@ repos:
           - --valid_odoo_versions={{ "%.1f"|format(odoo_version) }}
           - --rcfile=.pylintrc-mandatory
         additional_dependencies:
-          - isort==4.3.21
+          - isort==4.3.4
           - pylint-odoo==3.5.0
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v7.8.1


### PR DESCRIPTION
`pip` > 20.3 starts implementing a new dependency resolver which disallows having conflicting dependencies in the same environment. https://pip.pypa.io/en/stable/user_guide/?highlight=resolver#changes-to-the-pip-dependency-resolver-in-20-3-2020
This breaks the current pre-commit installation.

The errors are:
- `pylint-odoo` requires a specific version of `isort` and `pylint`, so when need to pin those
- The version of oca `maintainer-tools` we were using has a conflicting dependency with `docutils`

This fix pins the required versions until the hooks upstream update their dependencies to be compatible with each other.

TT27232