### PR TITLE
Warn about manual edits

### DIFF
--- a/{{ _copier_conf.answers_file }}.jinja
+++ b/{{ _copier_conf.answers_file }}.jinja
@@ -1,2 +1,2 @@
-# Changes here will be overwritten by Copier
+# Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
 {{ _copier_answers|to_nice_yaml }}


### PR DESCRIPTION
This confuses users. Following https://github.com/copier-org/copier/pull/317 I add this warn.