### PR TITLE
Update pylint configuration

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -101,16 +101,16 @@ repos:
           - --exit-zero
         verbose: true
         additional_dependencies:
-          - isort==4.3.4
-          - pylint-odoo==3.5.0
+          - isort==4.3.21
+          - pylint-odoo==3.6.0
       - id: pylint
         name: pylint with mandatory checks
         args:
           - --valid_odoo_versions={{ "%.1f"|format(odoo_version) }}
           - --rcfile=.pylintrc-mandatory
         additional_dependencies:
-          - isort==4.3.4
-          - pylint-odoo==3.5.0
+          - isort==4.3.21
+          - pylint-odoo==3.6.0
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v7.8.1
     hooks:


### PR DESCRIPTION
`isort` version was pinned to avoid `pip` installation conflicts (See https://github.com/Tecnativa/doodba-copier-template/pull/197/commits/5dcdeb70dfa23378581d9975a64dc834504afec4 and https://github.com/OCA/pylint-odoo/issues/306)

Seems like this issue has been fixed upstream (See https://github.com/OCA/pylint-odoo/commit/fd90fc89d4c03db01a0290f1fc84b5cc2f1e78c9)

Therefore, we can bump the `pylint-odoo` version to include the fix and loose the old `isort` version.
Partially reverts 5dcdeb70dfa23378581d9975a64dc834504afec4

@Tecnativa
TT27232