### PR TITLE
Migrate images to ghcr + Small improvements

### DIFF
--- a/README.md.jinja
+++ b/README.md.jinja
@@ -1,9 +1,16 @@
+{%- import "_macros.jinja" as macros -%}
 [![Doodba deployment](https://img.shields.io/badge/deployment-doodba-informational)](https://github.com/Tecnativa/doodba)
 [![Last template update](https://img.shields.io/badge/last%20template%20update-{{ _copier_answers._commit|replace('-', '--') }}-informational)](https://github.com/Tecnativa/doodba-copier-template/tree/{{ _copier_answers._commit }})
 [![Odoo](https://img.shields.io/badge/odoo-v{{ odoo_version }}-a3478a)](https://github.com/odoo/odoo/tree/{{ odoo_version }})
 {%- if gitlab_url %}
 [![pipeline status]({{ gitlab_url }}/badges/{{ odoo_version }}/pipeline.svg)]({{ gitlab_url }}/commits/{{ odoo_version }})
 [![coverage report]({{ gitlab_url }}/badges/{{ odoo_version }}/coverage.svg)]({{ gitlab_url }}/commits/{{ odoo_version }})
+{%- endif %}
+{%- if domains_prod %}
+[![Deployment data](https://img.shields.io/badge/Deployment-prod-green)](http://{{ macros.first_main_domain(domains_prod)|tojson }})
+{%- endif %}
+{%- if domains_test %}
+[![Deployment data](https://img.shields.io/badge/Deployment-demo-yellow)](http://{{ macros.first_main_domain(domains_test)|tojson }})
 {%- endif %}
 {%- if project_license %}
 [![{{ project_license }} license](https://img.shields.io/badge/license-{{ project_license|replace("-", "--") }}-{%- if project_license in ["OEEL-1.0", "OPL-1.0"] %}critical{%- else %}success{%- endif %}})](LICENSE)

--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -50,7 +50,7 @@ services:
   {%- if smtp_relay_host %}
 
   smtpreal:
-    image: tvial/docker-mailserver:latest
+    image: ghcr.io/docker-mailserver/docker-mailserver:{{ smtp_relay_version }}
     domainname: "{{ smtp_canonical_default }}"
     stop_grace_period: 1m
     volumes:
@@ -83,7 +83,7 @@ services:
   {%- if backup_dst %}
 
   backup:
-    image: tecnativa/duplicity:postgres{% if backup_dst.startswith(('boto3+s3://', 's3://', 's3+http://')) %}-s3{% endif %}
+    image: ghcr.io/tecnativa/docker-duplicity-postgres{% if backup_dst.startswith(('boto3+s3://', 's3://', 's3+http://')) %}-s3{% endif %}:{{ backup_image_version }}
     hostname: backup
     {%- if macros.first_main_domain(domains_prod) %}
     domainname: {{ macros.first_main_domain(domains_prod) }}

--- a/copier.yml
+++ b/copier.yml
@@ -414,7 +414,7 @@ smtp_relay_password:
 smtp_relay_version:
   type: str
   when: *has_smtp
-  default: "8.0"
+  default: "9.0"
   help: >-
     Doodba uses docker-mailserver as the local mail relay.
 

--- a/copier.yml
+++ b/copier.yml
@@ -411,6 +411,17 @@ smtp_relay_password:
   help: >-
     What is your SMTP password?
 
+smtp_relay_version:
+  type: str
+  when: *has_smtp
+  default: "8.0"
+  help: >-
+    Doodba uses docker-mailserver as the local mail relay.
+
+    Which version of the image do you want to use? You can check which ones are
+    available in
+    https://github.com/orgs/docker-mailserver/packages/container/docker-mailserver/versions
+
 smtp_canonical_default:
   type: str
   when: *has_smtp
@@ -452,9 +463,22 @@ backup_dst:
 
     Where should the backups be stored?
 
-backup_email_from:
+backup_image_version:
   type: str
   when: &backup_present "{{ backup_dst and true }}"
+  default: "1.0"
+  help: >-
+    Doodba uses the docker-duplicity image to make the backups.
+
+    Which version of the image do you want to use? You can check which ones are
+    available in
+    https://github.com/orgs/Tecnativa/packages/container/docker-duplicity-postgres/versions
+    and
+    https://github.com/orgs/Tecnativa/packages/container/docker-duplicity-postgres-s3/versions
+
+backup_email_from:
+  type: str
+  when: *backup_present
   help: >-
     The backup container will send email reports if the SMTP relay is properly
     configured.

--- a/devel.yaml.jinja
+++ b/devel.yaml.jinja
@@ -11,7 +11,7 @@ version: "2.4"
 
 services:
   odoo_proxy:
-    image: tecnativa/whitelist
+    image: ghcr.io/tecnativa/docker-whitelist:latest
     depends_on:
       - odoo
     networks: &public
@@ -114,7 +114,7 @@ services:
   # Whitelist outgoing traffic for tests, reports, etc.
 {%- for host in whitelisted_hosts %}
   proxy_{{ host|replace(".", "_") }}:
-    image: tecnativa/whitelist
+    image: ghcr.io/tecnativa/docker-whitelist:latest
     networks:
       default:
         aliases:

--- a/docs/daily-usage.md
+++ b/docs/daily-usage.md
@@ -222,8 +222,8 @@ docker-compose -f prod.yaml up -d
 #### Backups
 
 Backups are only available in the production environment. They are provided by
-[tecnativa/duplicity:postgres-s3](https://github.com/Tecnativa/docker-duplicity). The
-structure of the backed up folder:
+[docker-duplicity](https://github.com/Tecnativa/docker-duplicity). The structure of the
+backed up folder:
 
 ```
 ├── prod.sql
@@ -322,7 +322,7 @@ networks:
 
 services:
   cdnjs_cloudflare_com:
-    image: tecnativa/whitelist
+    image: ghcr.io/tecnativa/docker-whitelist
     restart: unless-stopped
     networks:
       public:
@@ -334,7 +334,7 @@ services:
       PRE_RESOLVE: 1
 
   fonts_googleapis_com:
-    image: tecnativa/whitelist
+    image: ghcr.io/tecnativa/docker-whitelist
     restart: unless-stopped
     networks:
       public:
@@ -346,7 +346,7 @@ services:
       PRE_RESOLVE: 1
 
   fonts_gstatic_com:
-    image: tecnativa/whitelist
+    image: ghcr.io/tecnativa/docker-whitelist
     restart: unless-stopped
     networks:
       public:
@@ -358,7 +358,7 @@ services:
       PRE_RESOLVE: 1
 
   www_google_com:
-    image: tecnativa/whitelist
+    image: ghcr.io/tecnativa/docker-whitelist
     restart: unless-stopped
     networks:
       public:
@@ -370,7 +370,7 @@ services:
       PRE_RESOLVE: 1
 
   www_gravatar_com:
-    image: tecnativa/whitelist
+    image: ghcr.io/tecnativa/docker-whitelist
     restart: unless-stopped
     networks:
       public:
@@ -584,7 +584,7 @@ adding the whitelist proxy like this to your docker-compose.yml:
   ...
 
   maxmind_proxy:
-    image: tecnativa/whitelist
+    image: ghcr.io/tecnativa/docker-whitelist
     networks:
       default:
         aliases:

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -426,14 +426,14 @@ def img_build(c, pull=True):
     if pull:
         cmd += " --pull"
     with c.cd(str(PROJECT_ROOT)):
-        c.run(cmd, env=UID_ENV)
+        c.run(cmd, env=UID_ENV, pty=True)
 
 
 @task(develop)
 def img_pull(c):
     """Pull docker images."""
     with c.cd(str(PROJECT_ROOT)):
-        c.run("docker-compose pull")
+        c.run("docker-compose pull", pty=True)
 
 
 @task(develop)
@@ -550,6 +550,7 @@ def _test_in_debug_mode(c, odoo_command):
                     UID_ENV,
                     DOODBA_DEBUGPY_ENABLE="1",
                 ),
+                pty=True,
             )
         _logger.info("Waiting for services to spin up...")
         time.sleep(SERVICES_WAIT_TIME)
@@ -620,7 +621,7 @@ def stop(c, purge=False):
     else:
         cmd += " stop"
     with c.cd(str(PROJECT_ROOT)):
-        c.run(cmd)
+        c.run(cmd, pty=True)
 
 
 @task(
@@ -660,7 +661,7 @@ def restart(c, quick=True):
         cmd = f"{cmd} -t0"
     cmd = f"{cmd} odoo odoo_proxy"
     with c.cd(str(PROJECT_ROOT)):
-        c.run(cmd, env=UID_ENV)
+        c.run(cmd, env=UID_ENV, pty=True)
 
 
 @task(
@@ -681,4 +682,4 @@ def logs(c, tail=10, follow=True, container=None):
     if container:
         cmd += f" {container.replace(',', ' ')}"
     with c.cd(str(PROJECT_ROOT)):
-        c.run(cmd)
+        c.run(cmd, pty=True)

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -329,6 +329,24 @@ def write_code_workspace_file(c, cw_path=None):
                 "problemMatcher": [],
                 "options": {"statusbar": {"label": "$(history) Restart Odoo"}},
             },
+            {
+                "label": "See container logs",
+                "type": "process",
+                "command": "invoke",
+                "args": ["logs"],
+                "presentation": {
+                    "echo": True,
+                    "reveal": "always",
+                    "focus": False,
+                    "panel": "shared",
+                    "showReuseMessage": True,
+                    "clear": False,
+                },
+                "problemMatcher": [],
+                "options": {
+                    "statusbar": {"label": "$(list-selection) See container logs"}
+                },
+            },
         ],
     }
     # Sort project folders

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -457,7 +457,11 @@ def start(c, detach=True, debugpy=False):
                     DOODBA_DEBUGPY_ENABLE=str(int(debugpy)),
                 ),
             )
-            if not ("Recreating" in result.stdout or "Starting" in result.stdout):
+            if not (
+                "Recreating" in result.stdout
+                or "Starting" in result.stdout
+                or "Creating" in result.stdout
+            ):
                 restart(c)
         _logger.info("Waiting for services to spin up...")
         time.sleep(SERVICES_WAIT_TIME)

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -245,6 +245,24 @@ def write_code_workspace_file(c, cw_path=None):
                 "options": {"statusbar": {"label": "$(play-circle) Start Odoo"}},
             },
             {
+                "label": "Install current module",
+                "type": "process",
+                "command": "invoke",
+                "args": ["install", "--cur-file", "${file}", "restart"],
+                "presentation": {
+                    "echo": True,
+                    "reveal": "always",
+                    "focus": True,
+                    "panel": "shared",
+                    "showReuseMessage": True,
+                    "clear": False,
+                },
+                "problemMatcher": [],
+                "options": {
+                    "statusbar": {"label": "$(symbol-property) Install module"}
+                },
+            },
+            {
                 "label": "Run Odoo Tests for current module",
                 "type": "process",
                 "command": "invoke",
@@ -474,16 +492,18 @@ def start(c, detach=True, debugpy=False):
         "core": "Install all core addons. Default: False",
         "extra": "Install all extra addons. Default: False",
         "private": "Install all private addons. Default: False",
+        "cur-file": "Path to the current file."
+        " Addon name will be obtained from there to install.",
     },
 )
-def install(c, modules=None, core=False, extra=False, private=False):
+def install(c, modules=None, cur_file=None, core=False, extra=False, private=False):
     """Install Odoo addons
 
     By default, installs addon from directory being worked on,
     unless other options are specified.
     """
     if not (modules or core or extra or private):
-        cur_module = _get_cwd_addon(Path.cwd())
+        cur_module = _get_cwd_addon(cur_file or Path.cwd())
         if not cur_module:
             raise exceptions.ParseError(
                 msg="Odoo addon to install not found. "

--- a/tests/test_settings_effect.py
+++ b/tests/test_settings_effect.py
@@ -13,10 +13,12 @@ from plumbum.cmd import docker_compose
     "backup_dst",
     (None, "s3://example", "s3+http://example", "boto3+s3://example", "sftp://example"),
 )
+@pytest.mark.parametrize("backup_image_version", ("1.0"))
 @pytest.mark.parametrize("smtp_relay_host", (None, "example"))
 def test_backup_config(
     backup_deletion: bool,
     backup_dst: Union[None, str],
+    backup_image_version: str,
     cloned_template: Path,
     smtp_relay_host: Union[None, str],
     supported_odoo_version: float,
@@ -26,6 +28,7 @@ def test_backup_config(
     data = {
         "backup_deletion": backup_deletion,
         "backup_dst": backup_dst,
+        "backup_image_version": backup_image_version,
         "odoo_version": supported_odoo_version,
         "smtp_relay_host": smtp_relay_host,
     }
@@ -47,9 +50,17 @@ def test_backup_config(
         return
     # Check selected duplicity image
     if "s3" in backup_dst:
-        assert prod["services"]["backup"]["image"] == "tecnativa/duplicity:postgres-s3"
+        assert prod["services"]["backup"][
+            "image"
+        ] == "ghcr.io/tecnativa/docker-duplicity-postgres-s3:{}".format(
+            backup_image_version
+        )
     else:
-        assert prod["services"]["backup"]["image"] == "tecnativa/duplicity:postgres"
+        assert prod["services"]["backup"][
+            "image"
+        ] == "ghcr.io/tecnativa/docker-duplicity-postgres:{}".format(
+            backup_image_version
+        )
     # Check SMTP configuration
     if smtp_relay_host:
         assert "smtp" in prod["services"]


### PR DESCRIPTION
Images migrated to GHCR so far:
- docker-duplicity 
- docker-mailserver (the image we were using had been deprecated and might have been outdated. I referenced the stable release, but we should still do some testing before releasing it officially)
- docker-whitelist (depends on https://github.com/Tecnativa/docker-whitelist/pull/6)

Still waiting on response from other maintainers to have other images migrated as well, but this should reduce the impact of the restrictions of DockerHub already.

Also, some small improvements (suggestions):

1. Add a button to see container logs:
![image](https://user-images.githubusercontent.com/38977934/107763269-447a9080-6d26-11eb-81dc-b263e0f4155a.png)
As happens with the `Test module` button, it launches the task and automatically focuses the terminal there to see the logs.
2. The `invoke start` command was recreating the containers even if they had just been created. This prevents that.
3. Add 2 simple badges at the README of the generated project pointing to the `prod` and `test` deployment environments, if defined. 
![image](https://user-images.githubusercontent.com/38977934/107763738-fade7580-6d26-11eb-93fa-09b8438f404e.png)

ping @Yajo 
