### PR TITLE
Disable GeoIp in test env

### DIFF
--- a/test.yaml.jinja
+++ b/test.yaml.jinja
@@ -18,6 +18,9 @@ services:
       WITHOUT_DEMO: "${DOODBA_WITHOUT_DEMO-all}"
       SMTP_PORT: "1025"
       SMTP_SERVER: smtplocal
+      # Disable GeoIp in demo allways
+      GEOIP_ACCOUNT_ID: ""
+      GEOIP_LICENSE_KEY: ""
     restart: unless-stopped
     depends_on:
       - db


### PR DESCRIPTION
Set GeoIp env variables empty so that GeoIp doesn't start in test environments.
Making use of https://github.com/Tecnativa/doodba/blob/master/entrypoint.d/45-geoip#L14 constraint.

@Tecnativa
TT28395