### PR TITLE
Run git-aggreator in a tty enabled env

### DIFF
--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -370,6 +370,7 @@ def git_aggregate(c):
         c.run(
             "docker-compose --file setup-devel.yaml run --rm odoo",
             env=UID_ENV,
+            pty=True,
         )
     write_code_workspace_file(c)
     for git_folder in SRC_PATH.glob("*/.git/.."):


### PR DESCRIPTION
Seems to be necessary after `docker` update to v20.10+
Fixes #223

@Tecnativa
TT28516

ping @Yajo