### PR TITLE
Improve install and test tasks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,10 +78,8 @@ jobs:
       # Non concurrent first (in parallel)
       - run: poetry run invoke test
         env:
-          DOCKER_TEST: 1
           SELECTED_ODOO_VERSIONS: ${{ matrix.odoo-version }}
       # Concurrent tests (isolated)
       - run: poetry run invoke test --sequential
         env:
-          DOCKER_TEST: 1
           SELECTED_ODOO_VERSIONS: ${{ matrix.odoo-version }}

--- a/tasks.py
+++ b/tasks.py
@@ -67,7 +67,7 @@ def lint(c, verbose=False):
 
 
 @task(develop)
-def test(c, verbose=False, sequential=False):
+def test(c, verbose=False, sequential=False, docker=True):
     """Test project.
 
     Add --sequential to run only sequential tests, with parallelization disabled.
@@ -75,6 +75,8 @@ def test(c, verbose=False, sequential=False):
     flags = ["--color=yes"]
     if verbose:
         flags.append("-vv")
+    if not docker:
+        flags.append("--skip-docker-tests")
     if sequential:
         flags.extend(["-m", "sequential"])
     else:

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -630,7 +630,7 @@ def stop(c, purge=False):
         "modules": "Comma-separated list of modules to install. Default: 'base'.",
     },
 )
-def resetdb(c, modules="base", dbname="devel"):
+def resetdb(c, modules="base", dbname="devel", populate=True):
     """Reset the specified database with the specified modules.
 
     Uses click-odoo-initdb behind the scenes, which has a caching system that
@@ -650,6 +650,8 @@ def resetdb(c, modules="base", dbname="devel"):
             env=UID_ENV,
             pty=True,
         )
+        if populate and ODOO_VERSION >= 11:
+            c.run(f"{_run} preparedb", env=UID_ENV, pty=True)
 
 
 @task(develop)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,15 @@ SELECTED_ODOO_VERSIONS = (
 ALL_TRAEFIK_VERSIONS = ("latest", "1.7")
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--skip-docker-tests",
+        action="store_true",
+        default=False,
+        help="Skip Docker tests",
+    )
+
+
 @pytest.fixture(params=ALL_ODOO_VERSIONS)
 def any_odoo_version(request) -> float:
     """Returns any usable odoo version."""
@@ -79,9 +88,9 @@ def cloned_template(tmp_path_factory):
 
 
 @pytest.fixture()
-def docker() -> LocalCommand:
-    if os.environ.get("DOCKER_TEST") != "1":
-        pytest.skip("Missing DOCKER_TEST=1 env variable")
+def docker(request) -> LocalCommand:
+    if request.config.getoption("--skip-docker-tests"):
+        pytest.skip("Skipping docker tests")
     try:
         from plumbum.cmd import docker
     except ImportError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,7 +189,9 @@ def socket_is_open(host, port):
     return False
 
 
-def generate_test_addon(addon_name, odoo_version, installable=True, ugly=False):
+def generate_test_addon(
+    addon_name, odoo_version, installable=True, ugly=False, dependencies=None
+):
     """Generates a simple addon for testing
     Can be an ugly addon to trigger pre-commit formatting
     """
@@ -210,6 +212,7 @@ def generate_test_addon(addon_name, odoo_version, installable=True, ugly=False):
                     {"{"}
                     'name':"{addon_name}",'license':'AGPL-3',
                     'version':'{odoo_version}.1.0.0',
+                    'depends': {dependencies or '["base"]'},
                     'installable': {installable},
                     'auto_install': False
                     {"}"}
@@ -221,7 +224,7 @@ def generate_test_addon(addon_name, odoo_version, installable=True, ugly=False):
                     import io,sys,odoo
                     _logger=getLogger(__name__)
                     class ResPartner(models.Model):
-                        _name='res.partner'
+                        _inherit='res.partner'
                         def some_method(self,test):
                             '''some weird
                                 docstring'''
@@ -237,6 +240,7 @@ def generate_test_addon(addon_name, odoo_version, installable=True, ugly=False):
                         "name": "{addon_name}",
                         "license": "AGPL-3",
                         "version": "{odoo_version}.1.0.0",
+                        "depends": {dependencies or '["base"]'},
                         "installable": {installable},
                         "auto_install": False,
                     {"}"}
@@ -256,7 +260,7 @@ def generate_test_addon(addon_name, odoo_version, installable=True, ugly=False):
 
 
                     class ResPartner(models.Model):
-                        _name = "res.partner"
+                        _inherit = "res.partner"
 
                         def some_method(self, test):
                             """some weird

--- a/tests/test_nitpicking.py
+++ b/tests/test_nitpicking.py
@@ -359,6 +359,7 @@ def test_pre_commit_in_subproject(
                     "name": "test_module",
                     "license": "AGPL-3",
                     "version": "{supported_odoo_version}.1.0.0",
+                    "depends": ["base"],
                     "installable": True,
                     "auto_install": False,
                 {"}"}
@@ -384,7 +385,7 @@ def test_pre_commit_in_subproject(
 
 
                 class ResPartner(models.Model):
-                    _name = "res.partner"
+                    _inherit = "res.partner"
 
                     def some_method(self, test):
                         """some weird

--- a/tests/test_tasks_downstream.py
+++ b/tests/test_tasks_downstream.py
@@ -118,10 +118,6 @@ def test_resetdb(
             assert _install_status("purchase") == "uninstalled"
             assert _install_status("sale") == "uninstalled"
             assert not _get_config_param("report.url")
-            if supported_odoo_version >= 11:
-                stdout = invoke("resetdb")  # --populate default
-                # report.url should be set in the DB
-                assert _get_config_param("report.url") == "http://localhost:8069"
             # Install "purchase"
             stdout = invoke("resetdb", "-m", "purchase")
             assert "Creating database cache" in stdout
@@ -146,6 +142,18 @@ def test_resetdb(
             assert _install_status("base") == "installed"
             assert _install_status("purchase") == "uninstalled"
             assert _install_status("sale") == "installed"
+            if supported_odoo_version >= 11:
+                invoke("preparedb")
+                assert _get_config_param("report.url") == "http://localhost:8069"
+                stdout = invoke("resetdb")  # --populate default
+                # report.url should be set in the DB
+                assert _get_config_param("report.url") == "http://localhost:8069"
+            else:
+                invoke(
+                    "resetdb"
+                )  # Despite new default --populate, shouldn't introduce error
+                with pytest.raises(ProcessExecutionError):
+                    invoke("preparedb")
     finally:
         safe_stop_env(
             tmp_path / "odoo" / "custom" / "src" / "odoo",

--- a/tests/test_tasks_downstream.py
+++ b/tests/test_tasks_downstream.py
@@ -315,20 +315,20 @@ def test_test_tasks(
             # Ensure "note" was installed and tests ran
             assert _install_status("note") == "installed"
             _tests_ran(stdout, supported_odoo_version, "note")
-            # Prepare environment for all private addons and "test" them
-            with local.cwd(tmp_path / "odoo" / "custom" / "src" / "private"):
-                generate_test_addon(
-                    "test_module", supported_odoo_version, dependencies='["mail"]'
-                )
-                invoke("resetdb", "--private", "--dependencies")
-                assert _install_status("mail") == "installed"
-                # Test "test_module" simple call in init mode (default)
-                assert _install_status("test_module") == "uninstalled"
-                stdout = invoke("test", "--private", retcode=None)
-                # Ensure "test_module" was installed and tests ran
-                assert _install_status("test_module") == "installed"
-            # Prepare environment for OCA addons and test them
-            if supported_odoo_version >= 9:
+            if supported_odoo_version >= 11:
+                # Prepare environment for all private addons and "test" them
+                with local.cwd(tmp_path / "odoo" / "custom" / "src" / "private"):
+                    generate_test_addon(
+                        "test_module", supported_odoo_version, dependencies='["mail"]'
+                    )
+                    invoke("resetdb", "--private", "--dependencies")
+                    assert _install_status("mail") == "installed"
+                    # Test "test_module" simple call in init mode (default)
+                    assert _install_status("test_module") == "uninstalled"
+                    stdout = invoke("test", "--private", retcode=None)
+                    # Ensure "test_module" was installed and tests ran
+                    assert _install_status("test_module") == "installed"
+                # Prepare environment for OCA addons and test them
                 with local.cwd(tmp_path / "odoo" / "custom" / "src"):
                     build_file_tree(
                         {


### PR DESCRIPTION
Some improvements to the `resetdb`, `install` and `test` flows:
1. Allow to prepare DB with config (Only for v11+)
1.1. In resetdb with flag
1.2. In a separate `preparedb` task
2. Improve `test` task
2.1. Test all core, extra and private modules with one command.
2.2. Test only explicit list of modules and skip some if needed (for multi-stage testing) (Only for v12+)
3. Improve `resetdb` task:
3.1 Install all core, extra and private modules present with extra flags
3.2 Install only dependencies of any list of modules passed.
4. Improve tests
4.1. Run docker tests by default
4.2. Add tests for new additions
5. Install `click-odoo` from acsone/click-odoo-contrib#93 to fix bug

- [x] Needs https://github.com/Tecnativa/doodba/pull/407

TT27635