### PR TITLE
Don't hardcode Jedi anymore

### DIFF
--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -111,7 +111,6 @@ def write_code_workspace_file(c, cw_path=None):
     cw_config["settings"].update(
         {
             "python.autoComplete.extraPaths": [f"{str(SRC_PATH)}/odoo"],
-            "python.languageServer": "Jedi",
             "python.linting.flake8Enabled": True,
             "python.linting.ignorePatterns": [f"{str(SRC_PATH)}/odoo/**/*.py"],
             "python.linting.pylintArgs": [


### PR DESCRIPTION
In 49cf5dbb1fe52462d84524221360b89972ffa731 we added this hardcoding because Pylance just didn't work fine.

According to my recent tests, latest versions work just fine. It's actually much faster to load file symbols.

By removing this setting from the workspace, we let each user choose the preferred language server.