### PR TITLE
feat: when testing, add DB_FILTER=devel

### DIFF
--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -678,7 +678,7 @@ def test(
     if debugpy:
         _test_in_debug_mode(c, odoo_command)
     else:
-        cmd = ["docker-compose", "run", "--rm", "odoo"]
+        cmd = ["docker-compose", "run", "--rm", "-e", "DB_FILTER=devel", "odoo"]
         cmd.extend(odoo_command)
         with c.cd(str(PROJECT_ROOT)):
             c.run(

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -619,6 +619,8 @@ def _get_module_list(c, modules=None, core=False, extra=False, private=False):
         "cur-file": "Path to the current file."
         " Addon name will be obtained from there to run tests",
         "mode": "Mode in which tests run. Options: ['init'(default), 'update']",
+        "db_filter": "DB_FILTER regex to pass to the test container Set to ''"
+        " to disable. Default: '^devel$'",
     },
 )
 def test(
@@ -631,6 +633,7 @@ def test(
     debugpy=False,
     cur_file=None,
     mode="init",
+    db_filter="^devel$",
 ):
     """Run Odoo tests
 
@@ -678,7 +681,10 @@ def test(
     if debugpy:
         _test_in_debug_mode(c, odoo_command)
     else:
-        cmd = ["docker-compose", "run", "--rm", "-e", "DB_FILTER=devel", "odoo"]
+        cmd = ["docker-compose", "run", "--rm"]
+        if db_filter:
+            cmd.extend(["-e", "DB_FILTER='%s'" % db_filter])
+        cmd.append("odoo")
         cmd.extend(odoo_command)
         with c.cd(str(PROJECT_ROOT)):
             c.run(


### PR DESCRIPTION
Multidb environments are harder to test because any http test lands in the db selector instead of the actual instance.

The solution is to add a dbfilter, but that would become problematic in devel when doing db backups or resetdb.

Thus, when `invoke test`ing, add automatically the DB_FILTER, so there's one less thing to worry about.