### PR TITLE
Move db filter to docker compose + Docker-compose down instead of stop

### DIFF
--- a/devel.yaml.jinja
+++ b/devel.yaml.jinja
@@ -51,6 +51,7 @@ services:
       WDB_WEB_PORT: "{{ macros.version_major(odoo_version) }}984"
       # To avoid installing demo data export DOODBA_WITHOUT_DEMO=all
       WITHOUT_DEMO: "${DOODBA_WITHOUT_DEMO-false}"
+      DB_FILTER: "^devel"
     volumes:
       - ./odoo/custom:/opt/odoo/custom:ro,z
       - ./odoo/auto:/opt/odoo/auto:rw,z

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -620,8 +620,6 @@ def _get_module_list(c, modules=None, core=False, extra=False, private=False):
         "cur-file": "Path to the current file."
         " Addon name will be obtained from there to run tests",
         "mode": "Mode in which tests run. Options: ['init'(default), 'update']",
-        "db_filter": "DB_FILTER regex to pass to the test container Set to ''"
-        " to disable. Default: '^devel$'",
     },
 )
 def test(
@@ -634,7 +632,6 @@ def test(
     debugpy=False,
     cur_file=None,
     mode="init",
-    db_filter="^devel$",
 ):
     """Run Odoo tests
 
@@ -683,8 +680,6 @@ def test(
         _test_in_debug_mode(c, odoo_command)
     else:
         cmd = ["docker-compose", "run", "--rm"]
-        if db_filter:
-            cmd.extend(["-e", "DB_FILTER='%s'" % db_filter])
         cmd.append("odoo")
         cmd.extend(odoo_command)
         with c.cd(str(PROJECT_ROOT)):

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -696,11 +696,9 @@ def test(
 )
 def stop(c, purge=False):
     """Stop and (optionally) purge environment."""
-    cmd = "docker-compose"
+    cmd = "docker-compose down"
     if purge:
-        cmd += " down --remove-orphans --rmi local --volumes"
-    else:
-        cmd += " stop"
+        cmd += " --remove-orphans --rmi local --volumes"
     with c.cd(str(PROJECT_ROOT)):
         c.run(cmd, pty=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,10 +289,13 @@ def _containers_running(exec_path):
         return False
 
 
-def safe_stop_env(exec_path):
+def safe_stop_env(exec_path, purge=True):
     with local.cwd(exec_path):
         try:
-            invoke("stop", "--purge")
+            args = ["stop"]
+            if purge:
+                args.append("--purge")
+            invoke.run(args)
         except ProcessExecutionError as e:
             if (
                 "has active endpoints" not in e.stderr
@@ -301,4 +304,4 @@ def safe_stop_env(exec_path):
                 raise e
             assert not _containers_running(
                 exec_path
-            ), "Containers running or not removed. 'stop --purge' command did not work."
+            ), "Containers running or not removed. 'stop [--purge]' command did not work."

--- a/tests/test_tasks_downstream.py
+++ b/tests/test_tasks_downstream.py
@@ -266,6 +266,7 @@ def test_install_test(
                 _tests_ran(stdout, supported_odoo_version, "note")
             # Test --debugpy and wait time call with
             invoke("stop")
+            safe_stop_env(tmp_path, purge=False)
             invoke("test", "-m", "note", "--debugpy", retcode=None)
             assert socket_is_open("127.0.0.1", int(supported_odoo_version) * 1000 + 899)
             stdout = _wait_for_test_to_start()


### PR DESCRIPTION
As mentioned in #244 (comment)
multiple DBs in an instance will cause problems in http tests
that land in the DB selector

When testing locally, the same can happend when developing controllers and APIs
When there is no session cookie, many calls fail as there is no explicit DB associated
We can limit that DB as, in devel, "devel" will be used pretty much 99% of the time
For the other cases, we can edit the DB filter manuallly

We can also remove it from the test task, as it will be included
in the docker compose file directly

---

Do a `docker-compose down` instead of a `stop`

1. When developing, this is a task generally performed when wanting to leave for another environment, not really when wanting to restart the environment relatively fast. For that, we have `restart`.

2. If regular down commands aren't executed, too many resources get accumulated (e.g. networks) so you end up having to run them manually. This would prevent that and help keep the docker environment clean in the OS.

3. There isn't a big performance impact