### PR TITLE
Filter module tests correctly

### DIFF
--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -678,7 +678,9 @@ def test(
     odoo_command.append(modules)
     if ODOO_VERSION >= 12:
         # Limit tests to explicit list
-        odoo_command.extend(["--test-tags", modules])
+        # Filter spec format (comma-separated)
+        # [-][tag][/module][:class][.method]
+        odoo_command.extend(["--test-tags", "/" + ",/".join(modules_list)])
     if debugpy:
         _test_in_debug_mode(c, odoo_command)
     else:


### PR DESCRIPTION
Append "/" to the module name before to comply with Odoo's filter mechanism

- [x] Needs https://github.com/Tecnativa/doodba-copier-template/pull/252