### PR TITLE
Add Docker Whitelist Proxy code snippet

### DIFF
--- a/.vscode/doodba.code-snippets
+++ b/.vscode/doodba.code-snippets
@@ -16,5 +16,23 @@
       "\t\t- ${40} refs/pull/${50:1234}/head"
     ],
     "description": "Git-aggregator repo definition with merges"
+  },
+  // See https://github.com/Tecnativa/doodba-copier-template/blob/main/docs/faq.md#how-can-i-whitelist-a-service-and-allow-external-access-to-it
+  "Docker Whitelist Proxy": {
+    "prefix": "proxy",
+    "scope": "yaml",
+    "body": [
+      "${10:proxy_}:",
+      "\timage: ghcr.io/tecnativa/docker-whitelist:latest",
+      "\tnetworks:",
+      "\t\tdefault:",
+      "\t\t\taliases:",
+      "\t\t\t\t- ${20:URL}",
+      "\t\tpublic:",
+      "\tenvironment:",
+      "\t\tTARGET: ${20}",
+      "\t\tPRE_RESOLVE: 1"
+    ],
+    "description": "Docker Whitelist definition"
   }
 }


### PR DESCRIPTION
Add a simple snippet to make it easier to add a proxy with `docker-whitelist`:

https://user-images.githubusercontent.com/38977934/121135578-8dea7080-c82c-11eb-8749-8aa1a690337d.mp4

