### PR TITLE
Resolve symlinks before attempting to find module name from file

### DIFF
--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -60,7 +60,7 @@ def _remove_auto_reload(file, orig_file):
 
 
 def _get_cwd_addon(file):
-    cwd = Path(file)
+    cwd = Path(file).resolve()
     manifest_file = False
     while PROJECT_ROOT < cwd:
         manifest_file = (cwd / "__manifest__.py").exists() or (


### PR DESCRIPTION
The file name that is passed to the function might be a symlink. 

Example: In Fedora SilverBlue, `/home/` is a symlink to `/var/home`. If you have a home folder (along with VSCode settings) that comes from a backed up system where home is `/home`, VSCode will pass the file name with `/home` as root, not `/var/home`, causing this script to fail. This avoids that.