### PR TITLE
Fix root certificate issue for old Doodba images

### DIFF
--- a/odoo/custom/build.d/{% if odoo_version < 11 %}10-fix-certs{% endif %}.jinja
+++ b/odoo/custom/build.d/{% if odoo_version < 11 %}10-fix-certs{% endif %}.jinja
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Remove revoked root certificate from list and update
+sed -i 's/mozilla\/DST_Root_CA_X3.crt/!mozilla\/DST_Root_CA_X3.crt/g' /etc/ca-certificates.conf
+update-ca-certificates

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -855,12 +855,14 @@ def after_update(c):
     """Execute some actions after a copier update or init"""
     # Make custom build script executable
     if ODOO_VERSION < 11:
-        script_file = Path(
-            PROJECT_ROOT, "odoo", "custom", "build.d", "20-update-pg-repos"
+        files = (
+            Path(PROJECT_ROOT, "odoo", "custom", "build.d", "20-update-pg-repos"),
+            Path(PROJECT_ROOT, "odoo", "custom", "build.d", "10-fix-certs"),
         )
-        cur_stat = script_file.stat()
-        # Like chmod ug+x
-        script_file.chmod(cur_stat.st_mode | stat.S_IXUSR | stat.S_IXGRP)
+        for script_file in files:
+            cur_stat = script_file.stat()
+            # Like chmod ug+x
+            script_file.chmod(cur_stat.st_mode | stat.S_IXUSR | stat.S_IXGRP)
 
 
 @task(


### PR DESCRIPTION
After the root LE certificate expired in October 1st, the list needs to be updated.
The alternative root certificate (ISRG Root X1) is already present as it was packaged with the old `ca-certificates`, so we just need to remove the old conflicting one to force the new one to be used.

See more at https://letsencrypt.org/certificates/

Closes https://github.com/Tecnativa/doodba-copier-template/issues/278

@Tecnativa
TT32281