### PR TITLE
Enable usage of git-autoshare

### DIFF
--- a/setup-devel.yaml.jinja
+++ b/setup-devel.yaml.jinja
@@ -27,16 +27,19 @@ services:
         COMPILE: "false"
         UID: "${UID:-1000}"
         GID: "${GID:-1000}"
+        GIT_AUTOSHARE: "1"
     networks:
       - public
     volumes:
       - ./odoo/custom/src:/opt/odoo/custom/src:rw,z
+      - ~/.cache/git-autoshare/:/home/odoo/.cache/git-autoshare/:rw,z
     environment:
       DEPTH_DEFAULT: 100
       # XXX Export these variables before running setup to own the files
       UID: "${UID:-1000}"
       GID: "${GID:-1000}"
       UMASK: "$UMASK"
+      GIT_AUTOSHARE: "1"
     user: root
     entrypoint: autoaggregate
 

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -18,10 +18,12 @@ from shutil import which
 from invoke import exceptions, task
 from invoke.util import yaml
 
+HOME = int(os.environ.get("HOME", 4))
 PROJECT_ROOT = Path(__file__).parent.absolute()
 SRC_PATH = PROJECT_ROOT / "odoo" / "custom" / "src"
 UID_ENV = {"GID": str(os.getgid()), "UID": str(os.getuid()), "UMASK": "27"}
 SERVICES_WAIT_TIME = int(os.environ.get("SERVICES_WAIT_TIME", 4))
+GIT_AUTOSHARE_CACHE_DIR = int(os.environ.get("GIT_AUTOSHARE_CACHE_DIR", 4))
 ODOO_VERSION = float(
     yaml.safe_load((PROJECT_ROOT / "common.yaml").read_text())["services"]["odoo"][
         "build"
@@ -403,6 +405,12 @@ def git_aggregate(c):
 
     Executes git-aggregator from within the doodba container.
     """
+    # Create git-autoshare cache folder if it doesn't exist
+    if GIT_AUTOSHARE_CACHE_DIR:
+        git_autoshare_cache_dir = Path(GIT_AUTOSHARE_CACHE_DIR)
+    else:
+        git_autoshare_cache_dir = Path(HOME) / ".cache" / "git-autoshare"
+    git_autoshare_cache_dir.mkdir(exist_ok=True)
     with c.cd(str(PROJECT_ROOT)):
         c.run(
             "docker-compose --file setup-devel.yaml run --rm odoo",


### PR DESCRIPTION
Needs https://github.com/Tecnativa/doodba/pull/453
Enables git-autoshare process for the local aggregation process
Sets up local cache even if user doesn't have git-autoshare installed and setup locally.

@Tecnativa
TT32042