### PR TITLE
[IMP] docs: 'invoke develop' requires pre-commit

### DIFF
--- a/docs/daily-usage.md
+++ b/docs/daily-usage.md
@@ -58,6 +58,7 @@ should know your toolbox, specifically these tools:
 - [invoke](https://www.pyinvoke.org/)
 - [Odoo](https://www.odoo.com/) 😆
 - [python](https://www.python.org/)
+- [pre-commit](https://pre-commit.com/)
 - [click-odoo-contrib][]
 
 Go read their docs and learn them fine.


### PR DESCRIPTION
If you follow the steps, but doesn't have pre-commit, then you get:

```python
subprocess.CalledProcessError: Command 'invoke develop' returned non-zero exit status 127.
```