### PR TITLE
feat: add dbfilter only to prod, defaulting to database name prefix

### DIFF
--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -16,7 +16,6 @@ services:
       EMAIL_FROM: "{{ smtp_default_from|default("", true) }}"
       PGDATABASE: &dbname {{ postgres_dbname }}
       PGUSER: &dbuser "{{ postgres_username }}"
-      DB_FILTER: "{{ odoo_dbfilter }}"
       PROXY_MODE: "{% if odoo_proxy %}true{% else %}false{% endif %}"
       LIST_DB: "{{ odoo_listdb | tojson }}"
     {%- if smtp_canonical_default %}
@@ -91,6 +90,7 @@ services:
     {%- endif %}
     init: true
     environment:
+      DBS_TO_INCLUDE: "{{ odoo_dbfilter }}"
       DST: "{{ backup_dst }}"
       {%- if smtp_relay_host %}
       EMAIL_FROM: "{{ backup_email_from }}"

--- a/copier.yml
+++ b/copier.yml
@@ -94,6 +94,14 @@ _migrations:
         - "{{ _copier_conf.dst_path }}"
         - "{{ _copier_conf.answers_file }}"
     after: *update_no_license
+  - version: v4.0.0a0
+    after:
+      - - invoke
+        - --search-root={{ _copier_conf.src_path }}
+        - --collection=migrations
+        - db-filter-prefix-default
+        - "{{ _copier_conf.dst_path }}"
+        - "{{ _copier_conf.answers_file }}"
 
 # Questions for the user
 odoo_version:
@@ -110,13 +118,6 @@ odoo_version:
     - 13.0
     - 14.0
     - 15.0
-
-odoo_dbfilter:
-  default: ".*"
-  type: str
-  help: >-
-    Set your Odoo db filter. It must be a regexp that matches the domain name being
-    visited. It is useful if you use Odoo in SaaS mode.
 
 odoo_proxy:
   default: traefik
@@ -373,6 +374,14 @@ postgres_password:
   type: str
   help: >-
     What will be your postgres user password?
+
+odoo_dbfilter:
+  default: "^{{ postgres_dbname }}"
+  type: str
+  help: >-
+    Set your Odoo db filter. It must be a regexp that matches the domain name being
+    visited. It is useful if you use Odoo in SaaS mode. Only applied to production
+    environment.
 
 smtp_default_from:
   type: str

--- a/migrations.py
+++ b/migrations.py
@@ -159,3 +159,33 @@ def update_no_license(c, dst_path, answers_rel_path):
                 license.unlink()
         except FileNotFoundError:
             pass  # LICENSE does not exist, and that's good
+
+
+@task
+def db_filter_prefix_default(c, dst_path, answers_rel_path):
+    """Update projects with default DB filter including main DB prefix.
+
+    In template version < 4.0.0, the default value for odoo_dbfilter was ".*"
+    always. Starting with 4.0.0, the default value will be applied only to
+    production environments and will include the main DB name as a prefix.
+
+    Update answers for projects that didn't change the default.
+    """
+    answers_path = Path(dst_path, answers_rel_path)
+    answers_yaml = _load_yaml(answers_path)
+    postgres_dbname = answers_yaml.get("postgres_dbname")
+    if answers_yaml.get("odoo_dbfilter") == ".*" and postgres_dbname:
+        answers_yaml["odoo_dbfilter"] = f"^{postgres_dbname}"
+        yaml.safe_dump(answers_yaml, answers_path.open("w"))
+        common_path = Path(dst_path, "common.yaml")
+        common_path.write_text(
+            common_path.read_text().replace(
+                'DBS_TO_INCLUDE: ".*"', f'DBS_TO_INCLUDE: "^{postgres_dbname}"'
+            )
+        )
+        prod_path = Path(dst_path, "prod.yaml")
+        prod_path.write_text(
+            prod_path.read_text().replace(
+                'DB_FILTER: ".*"', f'DB_FILTER: "^{postgres_dbname}"'
+            )
+        )

--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -14,6 +14,7 @@ services:
       - .docker/odoo.env
       - .docker/db-access.env
     environment:
+      DB_FILTER: "{{ odoo_dbfilter }}"
       DOODBA_ENVIRONMENT: "${DOODBA_ENVIRONMENT-prod}"
       INITIAL_LANG: "{{ odoo_initial_lang }}"
       {%- if smtp_relay_host %}


### PR DESCRIPTION
It doesn't make sense to add a DB filter to devel and test environments.

It makes sense to provide a saner default (only for production) where the filter matches any database prefixed with the name of the default database.

Benefits from https://github.com/Tecnativa/docker-duplicity/pull/75 to allow backing up only the used DBs by default.

@Tecnativa TT32631