### PR TITLE
fix(tasks): invoke's yaml incompatible with python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
         odoo-version:

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -16,7 +16,11 @@ from pathlib import Path
 from shutil import which
 
 from invoke import exceptions, task
-from invoke.util import yaml
+
+try:
+    import yaml
+except ImportError:
+    from invoke.util import yaml
 
 PROJECT_ROOT = Path(__file__).parent.absolute()
 SRC_PATH = PROJECT_ROOT / "odoo" / "custom" / "src"


### PR DESCRIPTION
Invoke's vendored pyyaml is incompatible with Python 3.10, as seen in https://github.com/pyinvoke/invoke/issues/820.

As we're using it, a good workaround is to use system's un-vendored version if available.

When installing invoke with pipx, you can get the normal pyyaml with:

```sh
pipx install invoke
pipx inject invoke pyyaml
```

That + this patch fixes the problem.

Besides, I'm removing builds for py3.6, which is EOL.