### PR TITLE
feat: full qualified image name everywhere

### DIFF
--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -46,7 +46,7 @@ services:
   {%- endif %}
 
   smtpfake:
-    image: mailhog/mailhog
+    image: docker.io/mailhog/mailhog
   {%- if smtp_relay_host %}
 
   smtpreal:

--- a/devel.yaml.jinja
+++ b/devel.yaml.jinja
@@ -86,7 +86,7 @@ services:
   {%- endif %}
 
   pgweb:
-    image: sosedoff/pgweb
+    image: docker.io/sosedoff/pgweb
     networks: *public
     ports:
       - "127.0.0.1:{{ macros.version_major(odoo_version) }}081:8081"
@@ -104,7 +104,7 @@ services:
       - "127.0.0.1:{{ macros.version_major(odoo_version) }}025:8025"
 
   wdb:
-    image: kozea/wdb
+    image: docker.io/kozea/wdb
     networks: *public
     ports:
       - "127.0.0.1:{{ macros.version_major(odoo_version) }}984:1984"

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -187,7 +187,7 @@ version: "2.1"
 
 services:
   proxy:
-    image: traefik:1.6-alpine
+    image: docker.io/traefik:1.6-alpine
     networks:
       shared:
       private:


### PR DESCRIPTION
This patch downloads the exact same images, but removes ambiguity.

When using podman as backend, you get this error with `docker-compose pull`:

    ERROR: for pgweb  failed to resolve image name: short-name resolution enforced but cannot prompt without a TTY

This is because podman supports configurable default registries to resolve ambiguous names, and when pulling an ambiguous-named image, it asks interactively how to resolve it:

```sh
podman pull sosedoff/pgweb
? Please select an image:
  ▸ registry.fedoraproject.org/sosedoff/pgweb:latest
    registry.access.redhat.com/sosedoff/pgweb:latest
    docker.io/sosedoff/pgweb:latest
    quay.io/sosedoff/pgweb:latest
```

Interactive prompts are disabled when using podman through the socket, which is the case when using docker-compose, and so it just fails.

With this patch, images are more specific, and podman works better with them out of the box.