### PR TITLE
Delete permanent redirect rule from Traefik 1 labels config

### DIFF
--- a/_traefik1_labels.yml.jinja
+++ b/_traefik1_labels.yml.jinja
@@ -49,9 +49,6 @@
 
       {#- Route redirections #}
       {%- if domain_group.redirect_to %}
-      {%- if domain_group.redirect_permanent %}
-      traefik.alt-{{ domain_group.loop.index0 }}.frontend.redirect.permanent: "true"
-      {%- endif %}
       traefik.alt-{{ domain_group.loop.index0 }}.frontend.redirect.regex: ^(.*)://([^/]+)/(.*)$$
       traefik.alt-{{ domain_group.loop.index0 }}.frontend.redirect.replacement: $$1://{{ domain_group.redirect_to }}/$$3
       {{-


### PR DESCRIPTION
They have the same name for v1 and v2, so having them in both places caused a conflict