### PR TITLE
fix: generate permanent redirections properly

### DIFF
--- a/_traefik2_labels.yml.jinja
+++ b/_traefik2_labels.yml.jinja
@@ -119,7 +119,7 @@
       {%- if domain_group.redirect_to %}
       {#- Redirections #}
       {%- if domain_group.redirect_permanent %}
-      traefik.alt-{{ domain_group.loop.index0 }}.frontend.redirect.permanent: "true"
+      traefik.http.middlewares.{{ key }}-redirect-{{ domain_group.loop.index0 }}.redirectRegex.permanent: "true"
       {%- endif %}
       traefik.http.middlewares.{{ key }}-redirect-{{ domain_group.loop.index0 }}.redirectRegex.regex: ^(.*)://([^/]+)/(.*)$$
       traefik.http.middlewares.{{ key }}-redirect-{{ domain_group.loop.index0 }}.redirectRegex.replacement: $$1://{{ domain_group.redirect_to }}/$$3


### PR DESCRIPTION
https://doc.traefik.io/traefik/middlewares/http/redirectregex/#permanent explains how to configure this for Traefik 2. It was being configured as for Traefik 1.

@moduon