### PR TITLE
fix: remove tty from git-aggregate task

### DIFF
--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -428,9 +428,8 @@ def git_aggregate(c):
     """
     with c.cd(str(PROJECT_ROOT)):
         c.run(
-            "docker-compose --file setup-devel.yaml run --rm odoo",
+            "docker-compose --file setup-devel.yaml run --rm -T odoo",
             env=UID_ENV,
-            pty=True,
         )
     write_code_workspace_file(c)
     for git_folder in SRC_PATH.glob("*/.git/.."):


### PR DESCRIPTION
Without this patch, if you mispell one git remote URI, `invoke git-aggregate` will get stuck, and the only clue you'll get to know why will be a message like this buried under a lot of "success" logs:

    Username for 'https://github.com':

Now, you get a proper error because there's no TTy associated with the process, so it cannot ask for input and will produce a meaningful error.

@moduon MT-460