### PR TITLE
fix: update https redirection method

### DIFF
--- a/_traefik2_labels.yml.jinja
+++ b/_traefik2_labels.yml.jinja
@@ -88,9 +88,9 @@
       traefik.http.middlewares.{{ key }}-compress.compress: "true"
       ? traefik.http.middlewares.{{ key }}-forbid-crawlers.headers.customResponseHeaders.X-Robots-Tag
       : "noindex, nofollow"
-      traefik.http.middlewares.{{ key }}-forceSecure.headers.forceSTSHeader: "true"
-      traefik.http.middlewares.{{ key }}-forceSecure.headers.sslRedirect: "true"
-
+      traefik.http.middlewares.{{ key }}-addSTS.headers.forceSTSHeader: "true"
+      traefik.http.middlewares.{{ key }}-forceSecure.redirectScheme.scheme: https
+      traefik.http.middlewares.{{ key }}-forceSecure.redirectScheme.permanent: "true"
       {%- if cidr_whitelist %}
       {#- Declare whitelist middleware #}
       ? traefik.http.middlewares.{{ key }}-whitelist.IPWhiteList.sourceRange
@@ -113,7 +113,7 @@
         {%- set _ns.basic_middlewares = _ns.basic_middlewares + ["whitelist"] %}
       {%- endif %}
       {%- if domain_group.cert_resolver %}
-        {%- set _ns.basic_middlewares = _ns.basic_middlewares + ["forceSecure"] %}
+        {%- set _ns.basic_middlewares = _ns.basic_middlewares + ["addSTS", "forceSecure"] %}
       {%- endif %}
 
       {%- if domain_group.redirect_to %}

--- a/test.yaml.jinja
+++ b/test.yaml.jinja
@@ -101,7 +101,7 @@ services:
         {%- set _ns.basic_middlewares = _ns.basic_middlewares + ["whitelist"] %}
       {%- endif %}
       {%- if domain_group.cert_resolver %}
-        {%- set _ns.basic_middlewares = _ns.basic_middlewares + ["forceSecure"] %}
+        {%- set _ns.basic_middlewares = _ns.basic_middlewares + ["addSTS", "forceSecure"] %}
       {%- endif %}
       {{-
         traefik2_labels.router(


### PR DESCRIPTION
Today I started noticing warnings like this in Traefik logs:

    SSLRedirect is deprecated, please use entrypoint redirection instead.

Indeed [the redirection method we were using is deprecated][1]. I changed it for [the most similar one][2].

[1]: https://doc.traefik.io/traefik/migration/v2/#headers-middleware-ssl-redirect-options
[2]: https://doc.traefik.io/traefik/middlewares/http/redirectscheme/