### PR TITLE
fix(podman): stop odoo before installing module

### DIFF
--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -555,6 +555,7 @@ def install(
     if modules:
         cmd += f" -w {modules}"
     with c.cd(str(PROJECT_ROOT)):
+        c.run("docker-compose stop odoo")
         c.run(
             cmd,
             env=UID_ENV,


### PR DESCRIPTION
This will make it work with podman 4 out of the box. Podman 4 still doesn't support `--link`, which is used by docker-compose when starting a parallel container. The fix is quite simple: just stop odoo before installing. The vscode task automatically calls `restart` after installation, which makes Odoo start again. Docker users will notice no difference.