### PR TITLE
[IMP] Change pre-commit flake8 URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     rev: 5.5.1
     hooks:
       - id: isort
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.8.3
     hooks:
       - id: flake8

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -92,7 +92,7 @@ repos:
       - id: check-xml
       - id: mixed-line-ending
         args: ["--fix=lf"]
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.8.3
     hooks:
       - id: flake8


### PR DESCRIPTION
Currently gitlab.com (and therefore https://gitlab.com/pycqa/flake8) is banned to some countries (such as Cuba, due to the US blockade).
So, I think we can change the pre-commit configuration to use the GITHUB flake8 repository instead of the GITLAB one (https://gitlab.com/pycqa/flake8 -> https://github.com/pycqa/ flake8) since that gitlab repository is a mirror of the github one. This way we will have the original repository and also we do not affect anyone from any country in the use of pre-commit with this configuration.