### PR TITLE
[FIX] pre-commit flake8 needs importlib-metadata<5.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     rev: 3.8.3
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-bugbear==20.1.4]
+        additional_dependencies: ["flake8-bugbear==20.1.4", "importlib-metadata<5.0.0"]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.1.2
     hooks:

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -98,12 +98,12 @@ repos:
       - id: flake8
         name: flake8 except __init__.py
         exclude: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==20.1.4"]
+        additional_dependencies: ["flake8-bugbear==20.1.4", "importlib-metadata<5.0.0"]
       - id: flake8
         name: flake8 only __init__.py
         args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
         files: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==20.1.4"]
+        additional_dependencies: ["flake8-bugbear==20.1.4", "importlib-metadata<5.0.0"]
   - repo: https://github.com/pycqa/pylint
     rev: v2.11.1
     hooks:


### PR DESCRIPTION
with new importlib-metadata otherwise we get
AttributeError: 'EntryPoints' object has no attribute 'get'

on our CI we got the following errors
```
Traceback (most recent call last):
  File "/home/copier/.local/bin/copier", line 8, in <module>
    sys.exit(CopierApp.run())
  File "/home/copier/.local/pipx/venvs/copier/lib/python3.7/site-packages/plumbum/cli/application.py", line 629, in run
    inst, retcode = subapp.run(argv, exit=False)
  File "/home/copier/.local/pipx/venvs/copier/lib/python3.7/site-packages/plumbum/cli/application.py", line 624, in run
    retcode = inst.main(*tailargs)
  File "/home/copier/.local/pipx/venvs/copier/lib/python3.7/site-packages/copier/cli.py", line 38, in _wrapper
    return method(*args, **kwargs)
  File "/home/copier/.local/pipx/venvs/copier/lib/python3.7/site-packages/copier/cli.py", line 297, in main
    dst_path=destination_path, only_diff=self.only_diff,
  File "/home/copier/.local/pipx/venvs/copier/lib/python3.7/site-packages/copier/cli.py", line 187, in _copy
    **kwargs,
  File "/home/copier/.local/pipx/venvs/copier/lib/python3.7/site-packages/copier/main.py", line 145, in copy
    update_diff(conf=conf)
  File "/home/copier/.local/pipx/venvs/copier/lib/python3.7/site-packages/copier/main.py", line 264, in update_diff
    git("commit", "--allow-empty", "-am", "dumb commit 2")
  File "/home/copier/.local/pipx/venvs/copier/lib/python3.7/site-packages/plumbum/commands/base.py", line 99, in __call__
    return self.run(args, **kwargs)[1]
  File "/home/copier/.local/pipx/venvs/copier/lib/python3.7/site-packages/plumbum/commands/base.py", line 240, in run
    return p.run()
  File "/home/copier/.local/pipx/venvs/copier/lib/python3.7/site-packages/plumbum/commands/base.py", line 201, in runner
    return run_proc(p, retcode, timeout)
  File "/home/copier/.local/pipx/venvs/copier/lib/python3.7/site-packages/plumbum/commands/processes.py", line 322, in run_proc
    return _check_process(proc, retcode, timeout, stdout, stderr)
  File "/home/copier/.local/pipx/venvs/copier/lib/python3.7/site-packages/plumbum/commands/processes.py", line 24, in _check_process
    proc.verify(retcode, timeout, stdout, stderr)
  File "/home/copier/.local/pipx/venvs/copier/lib/python3.7/site-packages/plumbum/machines/base.py", line 29, in verify
    getattr(self, "argv", None), self.returncode, stdout, stderr
plumbum.commands.processes.ProcessExecutionError: Unexpected exit code: 1
Command line: | /usr/bin/git commit --allow-empty -am 'dumb commit 2'
Stderr:       | forbidden files......................................(no files to check)Skipped
              | Update pre-commit excluded addons........................................Passed
              | autoflake................................................................Passed
              | black....................................................................Passed
              | pyupgrade................................................................Passed
              | isort except __init__.py.................................................Passed
              | prettier + plugin-xml....................................................Passed
              | Trim Trailing Whitespace.................................................Passed
              | Fix End of Files.........................................................Passed
              | Debug Statements (Python)................................................Passed
              | Fix python encoding pragma...............................................Passed
              | Check for case conflicts.................................................Passed
              | Check docstring is first.................................................Passed
              | Check that executables have shebangs.................(no files to check)Skipped
              | Check for merge conflicts................................................Passed
              | Check for broken symlinks............................(no files to check)Skipped
              | Check Xml............................................(no files to check)Skipped
              | Mixed line ending........................................................Passed
              | flake8 except __init__.py................................................Failed
              | - hook id: flake8
              | - exit code: 1
              | 
              | Traceback (most recent call last):
              |   File "/home/copier/.cache/pre-commit/repo2kigkb4o/py_env-python3/bin/flake8", line 8, in <module>
              |     sys.exit(main())
              |   File "/home/copier/.cache/pre-commit/repo2kigkb4o/py_env-python3/lib/python3.7/site-packages/flake8/main/cli.py", line 22, in main
              |     app.run(argv)
              |   File "/home/copier/.cache/pre-commit/repo2kigkb4o/py_env-python3/lib/python3.7/site-packages/flake8/main/application.py", line 360, in run
              |     self._run(argv)
              |   File "/home/copier/.cache/pre-commit/repo2kigkb4o/py_env-python3/lib/python3.7/site-packages/flake8/main/application.py", line 347, in _run
              |     self.initialize(argv)
              |   File "/home/copier/.cache/pre-commit/repo2kigkb4o/py_env-python3/lib/python3.7/site-packages/flake8/main/application.py", line 328, in initialize
              |     self.find_plugins(config_finder)
              |   File "/home/copier/.cache/pre-commit/repo2kigkb4o/py_env-python3/lib/python3.7/site-packages/flake8/main/application.py", line 153, in find_plugins
              |     self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
              |   File "/home/copier/.cache/pre-commit/repo2kigkb4o/py_env-python3/lib/python3.7/site-packages/flake8/plugins/manager.py", line 357, in __init__
              |     self.namespace, local_plugins=local_plugins
              |   File "/home/copier/.cache/pre-commit/repo2kigkb4o/py_env-python3/lib/python3.7/site-packages/flake8/plugins/manager.py", line 238, in __init__
              |     self._load_entrypoint_plugins()
              |   File "/home/copier/.cache/pre-commit/repo2kigkb4o/py_env-python3/lib/python3.7/site-packages/flake8/plugins/manager.py", line 254, in _load_entrypoint_plugins
              |     eps = importlib_metadata.entry_points().get(self.namespace, ())
              | AttributeError: 'EntryPoints' object has no attribute 'get'
              | 
              | flake8 only __init__.py..............................(no files to check)Skipped
              | pylint with optional checks..............................................Passed
              | - hook id: pylint
              | - duration: 3.83s
              | pylint with mandatory checks.............................................Passed
              | eslint...............................................(no files to check)Skipped
              | - hook id: eslint
Initialized empty Git repository in /tmp/copier.main.update_diff.dnfdalzs/.git/
pre-commit installed at .git/hooks/pre-commit
ERROR: error while running copier (1)
```

To fix it for us:
* i created a v4.2.0.1 with the commit in this pull request
* i updated our doodbas, because copier runs some checks with the current version of `.pre-commit-config.yaml`
  * `.copier-answers.yml`
    ```yaml
    _commit: v4.2.0.1
    ```
  * `.pre-commit-config.yaml`
    ```yaml
      - repo: https://gitlab.com/pycqa/flake8
    rev: 3.8.3
    hooks:
      - id: flake8
        name: flake8 except __init__.py
        exclude: /__init__\.py$
        additional_dependencies: ["flake8-bugbear==20.1.4", "importlib-metadata<5.0.0"] # downgraded importlib-metadata to fix https://stackoverflow.com/questions/73929564/entrypoints-object-has-no-attribute-get-digital-ocean
      - id: flake8
        name: flake8 only __init__.py
        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
        files: /__init__\.py$
        additional_dependencies: ["flake8-bugbear==20.1.4", "importlib-metadata<5.0.0"]
    ```
see also https://stackoverflow.com/a/73932581/925125

info @wt-io-it