### PR TITLE
[FIX] Update vscode python obsolete parameters

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,15 +16,6 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
 
-  // Custom file associations
-  "files.associations": {
-    // HACK https://github.com/samuelcolvin/jinjahtml-vscode/issues/47
-    ".env.jinja": "jinja-shell"
-  },
-
-  // Local spell dictionary
-  "cSpell.words": ["odoo", "pytest", "scaffoldings", "skipif", "venv"],
-
   // General settings
   "editor.formatOnSave": true,
   "markdown.extension.toc.updateOnSave": false,
@@ -32,11 +23,9 @@
   "python.formatting.provider": "black",
   "python.linting.flake8Enabled": true,
   "python.linting.pylintEnabled": true,
-  "python.pythonPath": "${workspaceRoot}/.venv/bin/python",
-  "python.testing.nosetestsEnabled": false,
+  "python.defaultInterpreterPath": "${workspaceRoot}/.venv/bin/python",
   "python.testing.pytestArgs": ["-nauto", "tests"],
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
-  "restructuredtext.confPath": "",
   "search.followSymlinks": false
 }

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -138,7 +138,8 @@ def write_code_workspace_file(c, cw_path=None):
                 "--load-plugins=pylint_odoo",
             ],
             "python.linting.pylintEnabled": True,
-            "python.pythonPath": "python%s" % (2 if ODOO_VERSION < 11 else 3),
+            "python.defaultInterpreterPath": "python%s"
+            % (2 if ODOO_VERSION < 11 else 3),
             "restructuredtext.confPath": "",
             "search.followSymlinks": False,
             "search.useIgnoreFiles": False,


### PR DESCRIPTION
- `python.pythonPath` is now `python.defaultInterpreterPath` (https://code.visualstudio.com/docs/python/environments#_manually-specify-an-interpreter)

cc @Tecnativa