### PR TITLE
[UPD] Update oca-addons-repo-template to latest branch

### DIFF
--- a/.eslintrc.yml.jinja
+++ b/.eslintrc.yml.jinja
@@ -1,1 +1,1 @@
-{%- include "vendor/oca-addons-repo-template/.eslintrc.yml" -%}
+{%- include "vendor/oca-addons-repo-template/src/{% if odoo_version > 12 %}.eslintrc.yml{% endif %}" -%}

--- a/tests/samples/mqt-diffs/v10.0-.pylintrc-mandatory.diff
+++ b/tests/samples/mqt-diffs/v10.0-.pylintrc-mandatory.diff
@@ -1,18 +1,20 @@
-6a7
+0a1
+> 
+6a8
 > manifest_required_authors=Odoo Community Association (OCA)
-8,9c9,11
+8,9c10,12
 < manifest_deprecated_keys=active
 < valid_odoo_versions=10.0
 ---
 > manifest_deprecated_keys=description,active
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
 > valid_odoo_versions=13.0
-21a24
+21a25
 >     development-status-allowed,
-28a32
+28a33
 >     license-allowed,
-30a35
+30a36
 >     manifest-required-author,
-37,38d41
+37,38d42
 <     missing-import-error,
 <     missing-manifest-dependency,

--- a/tests/samples/mqt-diffs/v10.0-.pylintrc.diff
+++ b/tests/samples/mqt-diffs/v10.0-.pylintrc.diff
@@ -1,19 +1,22 @@
-7c7
+0a1,2
+> 
+> 
+7c9
 < manifest_required_authors=Tecnativa
 ---
 > manifest_required_authors=Odoo Community Association (OCA)
-10,11c10,11
+10,11c12,13
 < license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 < valid_odoo_versions=10.0
 ---
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
 > valid_odoo_versions=13.0
-30a31
+30a33
 >     development-status-allowed,
-48,49d48
+48,49d50
 <     missing-import-error,
 <     missing-manifest-dependency,
-74a74
+74a76
 >     missing-manifest-dependency,
-82a83
+82a85
 > 

--- a/tests/samples/mqt-diffs/v11.0-.pylintrc-mandatory.diff
+++ b/tests/samples/mqt-diffs/v11.0-.pylintrc-mandatory.diff
@@ -1,18 +1,20 @@
-6a7
+0a1
+> 
+6a8
 > manifest_required_authors=Odoo Community Association (OCA)
-8,9c9,11
+8,9c10,12
 < manifest_deprecated_keys=active
 < valid_odoo_versions=11.0
 ---
 > manifest_deprecated_keys=description,active
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
 > valid_odoo_versions=13.0
-21a24
+21a25
 >     development-status-allowed,
-28a32
+28a33
 >     license-allowed,
-30a35
+30a36
 >     manifest-required-author,
-37,38d41
+37,38d42
 <     missing-import-error,
 <     missing-manifest-dependency,

--- a/tests/samples/mqt-diffs/v11.0-.pylintrc.diff
+++ b/tests/samples/mqt-diffs/v11.0-.pylintrc.diff
@@ -1,19 +1,22 @@
-7c7
+0a1,2
+> 
+> 
+7c9
 < manifest_required_authors=Tecnativa
 ---
 > manifest_required_authors=Odoo Community Association (OCA)
-10,11c10,11
+10,11c12,13
 < license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 < valid_odoo_versions=11.0
 ---
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
 > valid_odoo_versions=13.0
-30a31
+30a33
 >     development-status-allowed,
-48,49d48
+48,49d50
 <     missing-import-error,
 <     missing-manifest-dependency,
-74a74
+74a76
 >     missing-manifest-dependency,
-82a83
+82a85
 > 

--- a/tests/samples/mqt-diffs/v12.0-.pylintrc-mandatory.diff
+++ b/tests/samples/mqt-diffs/v12.0-.pylintrc-mandatory.diff
@@ -1,18 +1,20 @@
-6a7
+0a1
+> 
+6a8
 > manifest_required_authors=Odoo Community Association (OCA)
-8,9c9,11
+8,9c10,12
 < manifest_deprecated_keys=active
 < valid_odoo_versions=12.0
 ---
 > manifest_deprecated_keys=description,active
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
 > valid_odoo_versions=13.0
-21a24
+21a25
 >     development-status-allowed,
-28a32
+28a33
 >     license-allowed,
-30a35
+30a36
 >     manifest-required-author,
-37,38d41
+37,38d42
 <     missing-import-error,
 <     missing-manifest-dependency,

--- a/tests/samples/mqt-diffs/v12.0-.pylintrc.diff
+++ b/tests/samples/mqt-diffs/v12.0-.pylintrc.diff
@@ -1,19 +1,22 @@
-7c7
+0a1,2
+> 
+> 
+7c9
 < manifest_required_authors=Tecnativa
 ---
 > manifest_required_authors=Odoo Community Association (OCA)
-10,11c10,11
+10,11c12,13
 < license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 < valid_odoo_versions=12.0
 ---
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
 > valid_odoo_versions=13.0
-30a31
+30a33
 >     development-status-allowed,
-48,49d48
+48,49d50
 <     missing-import-error,
 <     missing-manifest-dependency,
-74a74
+74a76
 >     missing-manifest-dependency,
-82a83
+82a85
 > 

--- a/tests/samples/mqt-diffs/v13.0-.pylintrc-mandatory.diff
+++ b/tests/samples/mqt-diffs/v13.0-.pylintrc-mandatory.diff
@@ -1,16 +1,18 @@
-6a7
+0a1
+> 
+6a8
 > manifest_required_authors=Odoo Community Association (OCA)
-8c9,10
+8c10,11
 < manifest_deprecated_keys=active
 ---
 > manifest_deprecated_keys=description,active
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
-21a24
+21a25
 >     development-status-allowed,
-28a32
+28a33
 >     license-allowed,
-30a35
+30a36
 >     manifest-required-author,
-37,38d41
+37,38d42
 <     missing-import-error,
 <     missing-manifest-dependency,

--- a/tests/samples/mqt-diffs/v13.0-.pylintrc.diff
+++ b/tests/samples/mqt-diffs/v13.0-.pylintrc.diff
@@ -1,17 +1,20 @@
-7c7
+0a1,2
+> 
+> 
+7c9
 < manifest_required_authors=Tecnativa
 ---
 > manifest_required_authors=Odoo Community Association (OCA)
-10c10
+10c12
 < license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 ---
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
-30a31
+30a33
 >     development-status-allowed,
-48,49d48
+48,49d50
 <     missing-import-error,
 <     missing-manifest-dependency,
-74a74
+74a76
 >     missing-manifest-dependency,
-82a83
+82a85
 > 

--- a/tests/samples/mqt-diffs/v14.0-.pylintrc-mandatory.diff
+++ b/tests/samples/mqt-diffs/v14.0-.pylintrc-mandatory.diff
@@ -1,16 +1,18 @@
-6a7
+0a1
+> 
+6a8
 > manifest_required_authors=Odoo Community Association (OCA)
-8c9,10
+8c10,11
 < manifest_deprecated_keys=active
 ---
 > manifest_deprecated_keys=description,active
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
-21a24
+21a25
 >     development-status-allowed,
-28a32
+28a33
 >     license-allowed,
-30a35
+30a36
 >     manifest-required-author,
-37,38d41
+37,38d42
 <     missing-import-error,
 <     missing-manifest-dependency,

--- a/tests/samples/mqt-diffs/v14.0-.pylintrc.diff
+++ b/tests/samples/mqt-diffs/v14.0-.pylintrc.diff
@@ -1,17 +1,20 @@
-7c7
+0a1,2
+> 
+> 
+7c9
 < manifest_required_authors=Tecnativa
 ---
 > manifest_required_authors=Odoo Community Association (OCA)
-10c10
+10c12
 < license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 ---
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
-30a31
+30a33
 >     development-status-allowed,
-48,49d48
+48,49d50
 <     missing-import-error,
 <     missing-manifest-dependency,
-74a74
+74a76
 >     missing-manifest-dependency,
-82a83
+82a85
 > 

--- a/tests/samples/mqt-diffs/v15.0-.pylintrc-mandatory.diff
+++ b/tests/samples/mqt-diffs/v15.0-.pylintrc-mandatory.diff
@@ -1,16 +1,54 @@
-6a7
+0a1
+> 
+6a8
 > manifest_required_authors=Odoo Community Association (OCA)
-8c9,10
+8c10,11
 < manifest_deprecated_keys=active
 ---
 > manifest_deprecated_keys=description,active
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
-21a24
+21a25
 >     development-status-allowed,
-28a32
+28a33
 >     license-allowed,
-30a35
+30a36
 >     manifest-required-author,
-37,38d41
+37,38d42
 <     missing-import-error,
 <     missing-manifest-dependency,
+56c60,92
+<     xml-syntax-error
+---
+>     xml-syntax-error,
+>     attribute-string-redundant,
+>     character-not-valid-in-resource-link,
+>     consider-merging-classes-inherited,
+>     context-overridden,
+>     create-user-wo-reset-password,
+>     dangerous-filter-wo-user,
+>     dangerous-qweb-replace-wo-priority,
+>     deprecated-data-xml-node,
+>     deprecated-openerp-xml-node,
+>     duplicate-po-message-definition,
+>     except-pass,
+>     file-not-used,
+>     invalid-commit,
+>     manifest-maintainers-list,
+>     missing-newline-extrafiles,
+>     missing-readme,
+>     missing-return,
+>     odoo-addons-relative-import,
+>     old-api7-method-defined,
+>     po-msgstr-variables,
+>     po-syntax-error,
+>     renamed-field-parameter,
+>     resource-not-exist,
+>     str-format-used,
+>     test-folder-imported,
+>     translation-contains-variable,
+>     translation-positional-used,
+>     unnecessary-utf8-coding-comment,
+>     website-manifest-key-not-valid-uri,
+>     xml-attribute-translatable,
+>     xml-deprecated-qweb-directive,
+>     xml-deprecated-tree-attribute

--- a/tests/samples/mqt-diffs/v15.0-.pylintrc.diff
+++ b/tests/samples/mqt-diffs/v15.0-.pylintrc.diff
@@ -1,17 +1,53 @@
-7c7
+0a1,2
+> 
+> 
+7c9
 < manifest_required_authors=Tecnativa
 ---
 > manifest_required_authors=Odoo Community Association (OCA)
-10c10
+10c12
 < license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 ---
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
-30a31
+30a33
 >     development-status-allowed,
-48,49d48
+48,49d50
 <     missing-import-error,
 <     missing-manifest-dependency,
-74a74
+67a69,100
+>     attribute-string-redundant,
+>     character-not-valid-in-resource-link,
+>     consider-merging-classes-inherited,
+>     context-overridden,
+>     create-user-wo-reset-password,
+>     dangerous-filter-wo-user,
+>     dangerous-qweb-replace-wo-priority,
+>     deprecated-data-xml-node,
+>     deprecated-openerp-xml-node,
+>     duplicate-po-message-definition,
+>     except-pass,
+>     file-not-used,
+>     invalid-commit,
+>     manifest-maintainers-list,
+>     missing-newline-extrafiles,
+>     missing-readme,
+>     missing-return,
+>     odoo-addons-relative-import,
+>     old-api7-method-defined,
+>     po-msgstr-variables,
+>     po-syntax-error,
+>     renamed-field-parameter,
+>     resource-not-exist,
+>     str-format-used,
+>     test-folder-imported,
+>     translation-contains-variable,
+>     translation-positional-used,
+>     unnecessary-utf8-coding-comment,
+>     website-manifest-key-not-valid-uri,
+>     xml-attribute-translatable,
+>     xml-deprecated-qweb-directive,
+>     xml-deprecated-tree-attribute,
+74a108
 >     missing-manifest-dependency,
-82a83
+82a117
 > 

--- a/tests/samples/mqt-diffs/v16.0-.pylintrc-mandatory.diff
+++ b/tests/samples/mqt-diffs/v16.0-.pylintrc-mandatory.diff
@@ -1,16 +1,55 @@
-6a7
+0a1
+> 
+6a8
 > manifest_required_authors=Odoo Community Association (OCA)
-8c9,10
+8c10,11
 < manifest_deprecated_keys=active
 ---
 > manifest_deprecated_keys=description,active
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
-21a24
+21a25
 >     development-status-allowed,
-28a32
+28a33
 >     license-allowed,
-30a35
+30a36
 >     manifest-required-author,
-37,38d41
+37,38d42
 <     missing-import-error,
 <     missing-manifest-dependency,
+56c60,93
+<     xml-syntax-error
+---
+>     xml-syntax-error,
+>     attribute-string-redundant,
+>     character-not-valid-in-resource-link,
+>     consider-merging-classes-inherited,
+>     context-overridden,
+>     create-user-wo-reset-password,
+>     dangerous-filter-wo-user,
+>     dangerous-qweb-replace-wo-priority,
+>     deprecated-data-xml-node,
+>     deprecated-openerp-xml-node,
+>     duplicate-po-message-definition,
+>     except-pass,
+>     file-not-used,
+>     invalid-commit,
+>     manifest-maintainers-list,
+>     missing-newline-extrafiles,
+>     missing-readme,
+>     missing-return,
+>     odoo-addons-relative-import,
+>     old-api7-method-defined,
+>     po-msgstr-variables,
+>     po-syntax-error,
+>     renamed-field-parameter,
+>     resource-not-exist,
+>     str-format-used,
+>     test-folder-imported,
+>     translation-contains-variable,
+>     translation-positional-used,
+>     unnecessary-utf8-coding-comment,
+>     website-manifest-key-not-valid-uri,
+>     xml-attribute-translatable,
+>     xml-deprecated-qweb-directive,
+>     xml-deprecated-tree-attribute,
+>     external-request-timeout

--- a/tests/samples/mqt-diffs/v16.0-.pylintrc.diff
+++ b/tests/samples/mqt-diffs/v16.0-.pylintrc.diff
@@ -1,17 +1,54 @@
-7c7
+0a1,2
+> 
+> 
+7c9
 < manifest_required_authors=Tecnativa
 ---
 > manifest_required_authors=Odoo Community Association (OCA)
-10c10
+10c12
 < license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 ---
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
-30a31
+30a33
 >     development-status-allowed,
-48,49d48
+48,49d50
 <     missing-import-error,
 <     missing-manifest-dependency,
-74a74
+67a69,101
+>     attribute-string-redundant,
+>     character-not-valid-in-resource-link,
+>     consider-merging-classes-inherited,
+>     context-overridden,
+>     create-user-wo-reset-password,
+>     dangerous-filter-wo-user,
+>     dangerous-qweb-replace-wo-priority,
+>     deprecated-data-xml-node,
+>     deprecated-openerp-xml-node,
+>     duplicate-po-message-definition,
+>     except-pass,
+>     file-not-used,
+>     invalid-commit,
+>     manifest-maintainers-list,
+>     missing-newline-extrafiles,
+>     missing-readme,
+>     missing-return,
+>     odoo-addons-relative-import,
+>     old-api7-method-defined,
+>     po-msgstr-variables,
+>     po-syntax-error,
+>     renamed-field-parameter,
+>     resource-not-exist,
+>     str-format-used,
+>     test-folder-imported,
+>     translation-contains-variable,
+>     translation-positional-used,
+>     unnecessary-utf8-coding-comment,
+>     website-manifest-key-not-valid-uri,
+>     xml-attribute-translatable,
+>     xml-deprecated-qweb-directive,
+>     xml-deprecated-tree-attribute,
+>     external-request-timeout,
+74a109
 >     missing-manifest-dependency,
-82a83
+82a118
 > 

--- a/tests/samples/mqt-diffs/v8.0-.pylintrc-mandatory.diff
+++ b/tests/samples/mqt-diffs/v8.0-.pylintrc-mandatory.diff
@@ -1,18 +1,20 @@
-6a7
+0a1
+> 
+6a8
 > manifest_required_authors=Odoo Community Association (OCA)
-8,9c9,11
+8,9c10,12
 < manifest_deprecated_keys=active
 < valid_odoo_versions=8.0
 ---
 > manifest_deprecated_keys=description,active
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
 > valid_odoo_versions=13.0
-21a24
+21a25
 >     development-status-allowed,
-28a32
+28a33
 >     license-allowed,
-30a35
+30a36
 >     manifest-required-author,
-37,38d41
+37,38d42
 <     missing-import-error,
 <     missing-manifest-dependency,

--- a/tests/samples/mqt-diffs/v8.0-.pylintrc.diff
+++ b/tests/samples/mqt-diffs/v8.0-.pylintrc.diff
@@ -1,19 +1,22 @@
-7c7
+0a1,2
+> 
+> 
+7c9
 < manifest_required_authors=Tecnativa
 ---
 > manifest_required_authors=Odoo Community Association (OCA)
-10,11c10,11
+10,11c12,13
 < license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 < valid_odoo_versions=8.0
 ---
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
 > valid_odoo_versions=13.0
-30a31
+30a33
 >     development-status-allowed,
-48,49d48
+48,49d50
 <     missing-import-error,
 <     missing-manifest-dependency,
-74a74
+74a76
 >     missing-manifest-dependency,
-82a83
+82a85
 > 

--- a/tests/samples/mqt-diffs/v9.0-.pylintrc-mandatory.diff
+++ b/tests/samples/mqt-diffs/v9.0-.pylintrc-mandatory.diff
@@ -1,18 +1,20 @@
-6a7
+0a1
+> 
+6a8
 > manifest_required_authors=Odoo Community Association (OCA)
-8,9c9,11
+8,9c10,12
 < manifest_deprecated_keys=active
 < valid_odoo_versions=9.0
 ---
 > manifest_deprecated_keys=description,active
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
 > valid_odoo_versions=13.0
-21a24
+21a25
 >     development-status-allowed,
-28a32
+28a33
 >     license-allowed,
-30a35
+30a36
 >     manifest-required-author,
-37,38d41
+37,38d42
 <     missing-import-error,
 <     missing-manifest-dependency,

--- a/tests/samples/mqt-diffs/v9.0-.pylintrc.diff
+++ b/tests/samples/mqt-diffs/v9.0-.pylintrc.diff
@@ -1,19 +1,22 @@
-7c7
+0a1,2
+> 
+> 
+7c9
 < manifest_required_authors=Tecnativa
 ---
 > manifest_required_authors=Odoo Community Association (OCA)
-10,11c10,11
+10,11c12,13
 < license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,OPL-1,OEEL-1
 < valid_odoo_versions=9.0
 ---
 > license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
 > valid_odoo_versions=13.0
-30a31
+30a33
 >     development-status-allowed,
-48,49d48
+48,49d50
 <     missing-import-error,
 <     missing-manifest-dependency,
-74a74
+74a76
 >     missing-manifest-dependency,
-82a83
+82a85
 > 


### PR DESCRIPTION
- Get eslint fix for sourceType.
- Get latest definitions.
- Change eslint source path.

To check the differences in the submodule, go to

https://github.com/OCA/oca-addons-repo-template/compare/09544010ba14f9ca1a0e05b86bd8e31dc72494d3..master