### PR TITLE
fix(tasks): remove python hardcoded formatter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,6 +8,7 @@
     "firefox-devtools.vscode-firefox-debug",
     "mrorz.language-gettext",
     "ms-azuretools.vscode-docker",
+    "ms-python.black-formatter",
     "ms-python.python",
     "msjsdiag.debugger-for-chrome",
     "redhat.vscode-xml",

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -131,6 +131,7 @@ def write_code_workspace_file(c, cw_path=None):
     cw_config["settings"].update(
         {
             "python.autoComplete.extraPaths": [f"{str(SRC_PATH)}/odoo"],
+            "python.formatting.provider": "none",
             "python.linting.flake8Enabled": True,
             "python.linting.ignorePatterns": [f"{str(SRC_PATH)}/odoo/**/*.py"],
             "python.linting.pylintArgs": [
@@ -144,7 +145,7 @@ def write_code_workspace_file(c, cw_path=None):
             "search.followSymlinks": False,
             "search.useIgnoreFiles": False,
             # Language-specific configurations
-            "[python]": {"editor.defaultFormatter": "ms-python.python"},
+            "[python]": {"editor.defaultFormatter": "ms-python.black-formatter"},
             "[json]": {"editor.defaultFormatter": "esbenp.prettier-vscode"},
             "[jsonc]": {"editor.defaultFormatter": "esbenp.prettier-vscode"},
             "[markdown]": {"editor.defaultFormatter": "esbenp.prettier-vscode"},


### PR DESCRIPTION
Microsoft is moving Black support to its own extension: https://github.com/microsoft/vscode-black-formatter

There's no need to hardcode this formatter here. Besides, if you're using the Black-dedicated one, this way you get to use it also in DCT projects.