### PR TITLE
[FIX] Remove invalid initial version

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -45,7 +45,7 @@ _tasks:
   - invoke develop
 
 _migrations:
-  - version: v0.0.1-0-0
+  - version: v0.0.1
     after:
       - - invoke
         - --search-root={{ _copier_conf.src_path }}


### PR DESCRIPTION
The nomenclature used is not correct and not admitted by all versions of the library.