### PR TITLE
[FIX] pre-commit isort version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,8 +28,8 @@ repos:
       - id: pyupgrade
         args:
           - --keep-percent-format
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.5.1
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.11.5
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/flake8

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -54,8 +54,8 @@ repos:
       - id: pyupgrade
         args:
           - --keep-percent-format
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.5.1
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.11.5
     hooks:
       - id: isort
         name: isort except __init__.py


### PR DESCRIPTION
Fixes:
```
              |           RuntimeError: The Poetry configuration is invalid:
              |             - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
```

see https://github.com/PyCQA/isort/issues/2077