### PR TITLE
build(vscode): don't ignore settings, extensions, tasks...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,12 +15,12 @@
 **.orig
 
 # User-specific or editor-specific development files and settings
+.vscode/*
 !/.vscode/*.jinja
 !/.vscode/extensions.json
 !/.vscode/launch.json
 !/.vscode/settings.json
 !/.vscode/tasks.json
-.vscode/*
 /odoo/custom/src/private/.vscode/*
 /.venv
 /doodba.*.code-workspace


### PR DESCRIPTION
Before this patch, extension recommendations were no longer being propagated automatically to subprojects.

@moduon MT-2532