### PR TITLE
fix(podman): allow downloading correct backups

### DIFF
--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -84,10 +84,7 @@ services:
 
   backup:
     image: ghcr.io/tecnativa/docker-duplicity-postgres{% if backup_dst.startswith(('boto3+s3://', 's3://', 's3+http://')) %}-s3{% endif %}:{{ backup_image_version }}
-    hostname: backup
-    {%- if macros.first_main_domain(domains_prod) %}
-    domainname: {{ macros.first_main_domain(domains_prod) }}
-    {%- endif %}
+    hostname: backup{% if macros.first_main_domain(domains_prod) %}.{{ macros.first_main_domain(domains_prod) }}{% endif %}
     init: true
     environment:
       DBS_TO_INCLUDE: "{{ odoo_dbfilter }}"

--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -51,7 +51,7 @@ services:
 
   smtpreal:
     image: ghcr.io/docker-mailserver/docker-mailserver:{{ smtp_relay_version }}
-    domainname: "{{ smtp_canonical_default }}"
+    hostname: "smtp.{{ smtp_canonical_default }}"
     stop_grace_period: 1m
     volumes:
       - mailconfig:/tmp/docker-mailserver:z


### PR DESCRIPTION
`domainname` is not supported when the docker backend is podman. It is required to compute appropriately the prefixes in s3 flavored images.

With this patch, we make the container compatible with both docker and podman.

@moduon MT-2568