### PR TITLE
fix: safer merge conflict commit protection

### DIFF
--- a/.module-readme.rst.j2
+++ b/.module-readme.rst.j2
@@ -48,7 +48,8 @@
 {{- fragment('HISTORY', 'Changelog') -}}
 
 Credits
-=======
+{#- HACK Avoid conflicts with pre-commit's check-merge-conflict #}
+{{ "=======" }}
 
 {% if authors -%}
 Authors

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -107,6 +107,8 @@ repos:
       - id: check-docstring-first
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
+        args: [--assume-in-merge]
+        exclude: \.rst$ # HACK https://github.com/pre-commit/pre-commit-hooks/issues/985
       - id: check-symlinks
       - id: check-xml
       - id: mixed-line-ending


### PR DESCRIPTION
This is the configuration recommended upstream: https://copier.readthedocs.io/en/stable/updating/#preventing-commit-of-merge-conflicts

It is more important now that Copier supports inline conflict markers on updates.

@moduon MT-2626