### PR TITLE
fix: don't recommend sass-indented extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -12,7 +12,6 @@
     "ms-python.python",
     "msjsdiag.debugger-for-chrome",
     "redhat.vscode-xml",
-    "samuelcolvin.jinjahtml",
-    "syler.sass-indented"
+    "samuelcolvin.jinjahtml"
   ]
 }


### PR DESCRIPTION
Odoo uses scss. This extension only adds support for sass. Thus, it's useless to recommend it.