### PR TITLE
[FIX] Update longpolling route for Odoo 16.0

### DIFF
--- a/_traefik1_labels.yml.jinja
+++ b/_traefik1_labels.yml.jinja
@@ -43,7 +43,7 @@
       {%- endif %}
 {%- endmacro %}
 
-{%- macro odoo(domain_groups_list, paths_without_crawlers) %}
+{%- macro odoo(domain_groups_list, paths_without_crawlers, odoo_version) %}
       traefik.domain: {{ macros.first_main_domain(domain_groups_list)|tojson }}
       {%- call(domain_group) macros.domains_loop_grouped(domain_groups_list) %}
 
@@ -87,11 +87,12 @@
       }}
       {%- endif %}
       {%- if not domain_group.path_prefixes %}
+      {%- set longpolling_route = "/longpoling/" if odoo_version < 16 else "/websocket" -%}
       {{-
         router(
           prefix="longpolling",
           index0=domain_group.loop.index0,
-          rule=domains_rule(domain_group.hosts, ["/longpolling/"]),
+          rule=domains_rule(domain_group.hosts, [longpolling_route]),
           entrypoints=domain_group.entrypoints,
           port=8072,
         )

--- a/_traefik1_labels.yml.jinja
+++ b/_traefik1_labels.yml.jinja
@@ -87,7 +87,7 @@
       }}
       {%- endif %}
       {%- if not domain_group.path_prefixes %}
-      {%- set longpolling_route = "/longpoling/" if odoo_version < 16 else "/websocket" -%}
+      {%- set longpolling_route = "/longpolling/" if odoo_version < 16 else "/websocket" -%}
       {{-
         router(
           prefix="longpolling",

--- a/_traefik2_labels.yml.jinja
+++ b/_traefik2_labels.yml.jinja
@@ -154,12 +154,13 @@
 
       {#- Longpolling router #}
       {%- if not domain_group.path_prefixes %}
+      {%- set longpolling_route = "/longpoling/" if odoo_version < 16 else "/websocket" -%}
       {{-
         router(
           domain_group=domain_group,
           key=key,
           suffix="longpolling",
-          rule="%s && PathPrefix(`/longpolling/`)" % domains_rule(domain_group),
+          rule="%s && PathPrefix(`%s`)" % (domains_rule(domain_group), longpolling_route),
           service="longpolling",
           middlewares=_ns.basic_middlewares,
         )

--- a/_traefik2_labels.yml.jinja
+++ b/_traefik2_labels.yml.jinja
@@ -154,13 +154,13 @@
 
       {#- Longpolling router #}
       {%- if not domain_group.path_prefixes %}
-      {%- set longpolling_route = "/longpolling/" if odoo_version < 16 else "/websocket" -%}
+      {%- set longpolling_route = "PathPrefix(`/longpolling/`)" if odoo_version < 16 else "Path(`/websocket`)" -%}
       {{-
         router(
           domain_group=domain_group,
           key=key,
           suffix="longpolling",
-          rule="%s && PathPrefix(`%s`)" % (domains_rule(domain_group), longpolling_route),
+          rule="%s && %s" % (domains_rule(domain_group), longpolling_route),
           service="longpolling",
           middlewares=_ns.basic_middlewares,
         )

--- a/_traefik2_labels.yml.jinja
+++ b/_traefik2_labels.yml.jinja
@@ -154,7 +154,7 @@
 
       {#- Longpolling router #}
       {%- if not domain_group.path_prefixes %}
-      {%- set longpolling_route = "/longpoling/" if odoo_version < 16 else "/websocket" -%}
+      {%- set longpolling_route = "/longpolling/" if odoo_version < 16 else "/websocket" -%}
       {{-
         router(
           domain_group=domain_group,

--- a/devel.yaml.jinja
+++ b/devel.yaml.jinja
@@ -20,15 +20,9 @@ services:
     ports:
       - "127.0.0.1:{{ macros.version_major(odoo_version) }}899:6899"
       - "127.0.0.1:{{ macros.version_major(odoo_version) }}069:8069"
-      {%- if odoo_version >= 16 %}
       - "127.0.0.1:{{ macros.version_major(odoo_version) }}072:8072"
-      {%- endif %}
     environment:
-      {%- if odoo_version < 16 %}
-      PORT: "6899 8069"
-      {%- else %}
       PORT: "6899 8069 8072"
-      {%- endif %}
       TARGET: odoo
 
   odoo:

--- a/devel.yaml.jinja
+++ b/devel.yaml.jinja
@@ -20,8 +20,15 @@ services:
     ports:
       - "127.0.0.1:{{ macros.version_major(odoo_version) }}899:6899"
       - "127.0.0.1:{{ macros.version_major(odoo_version) }}069:8069"
+      {%- if odoo_version >= 16 %}
+      - "127.0.0.1:{{ macros.version_major(odoo_version) }}072:8072"
+      {%- endif %}
     environment:
+      {%- if odoo_version < 16 %}
       PORT: "6899 8069"
+      {%- else %}
+      PORT: "6899 8069 8072"
+      {%- endif %}
       TARGET: odoo
 
   odoo:

--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -37,7 +37,7 @@ services:
       doodba.domain.main: {{ macros.first_main_domain(domains_prod)|tojson }}
       {%- if odoo_proxy == "traefik" and domains_prod %}
       traefik.enable: "true"
-      {{- traefik1_labels.odoo(domains_prod, paths_without_crawlers) }}
+      {{- traefik1_labels.odoo(domains_prod, paths_without_crawlers, odoo_version) }}
       {{- traefik2_labels.common_middlewares(_key, cidr_whitelist) }}
       {{- traefik2_labels.odoo(
         domains_prod,

--- a/test.yaml.jinja
+++ b/test.yaml.jinja
@@ -35,7 +35,7 @@ services:
       doodba.domain.main: {{ macros.first_main_domain(domains_test)|tojson }}
       {%- if odoo_proxy == "traefik" and domains_test %}
       traefik.enable: "true"
-      {{- traefik1_labels.odoo(domains_test, ["/"]) }}
+      {{- traefik1_labels.odoo(domains_test, ["/"], odoo_version) }}
       {{- traefik2_labels.odoo(
         domains_test,
         cidr_whitelist,


### PR DESCRIPTION
As mentioned in https://github.com/Tecnativa/doodba/discussions/530, the old `/longpolling/` route was replaced by `/websocket` in Odoo 16.0 (see https://github.com/odoo/odoo/pull/75510). Currently, this results in the following error when a client tries to access the latter route (with the exception of threaded-mode odoo):
```
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 2002, in __call__
    response = request._serve_db()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1588, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1615, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1729, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 697, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/auto/addons/bus/controllers/websocket.py", line 23, in websocket
    return WebsocketConnectionHandler.open_connection(request)
  File "/opt/odoo/auto/addons/bus/websocket.py", line 818, in open_connection
    Websocket(request.httprequest.environ['socket'], request.session),
KeyError: 'socket'
```

This is caused by an undefined `socket`, which is only defined in `environ` when the request goes to the [GeventServer](https://github.com/odoo/odoo/blob/16.0/odoo/service/server.py#L723)'s [ProxyHandler](https://github.com/odoo/odoo/blob/16.0/odoo/service/server.py#L703) or to the [ThreadedServer](https://github.com/odoo/odoo/blob/16.0/odoo/service/server.py#L170), which uses a modified [RequestHandler](https://github.com/odoo/odoo/blob/16.0/odoo/service/server.py#L134).

For Doodba projects using Traefik, the solution is pretty straightforward: update the longpolling route so that WebSocket traffic passes through the `GeventServer`. Apparently, Traefik handles WebSocket requests the same as it would HTTP ones, as  stated [here](https://stackoverflow.com/a/46316349), so no further changes should be required. I've personally tested the  changes presented in this PR and had no issues.

As for local environments running in pre-fork mode, I've applied the changes proposed by @yelizariev in https://github.com/Tecnativa/doodba/discussions/530, but making it work properly would still require the configuration of an external proxy such as Nginx.