### PR TITLE
imp: pre-commit config: add 'odoo_pre_commit_hooks'

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -43,6 +43,14 @@ repos:
         args:
           - --addons-dir
           - odoo/custom/src/private
+  {% if odoo_version >= 14 -%}
+  - repo: https://github.com/OCA/odoo-pre-commit-hooks
+    rev: v0.0.29
+    hooks:
+      - id: oca-checks-odoo-module
+      - id: oca-checks-po
+        args: ["--fix"]
+  {% endif -%}
   - repo: https://github.com/myint/autoflake
     rev: v2.2.0
     hooks:


### PR DESCRIPTION
As mentioned here: https://github.com/Tecnativa/doodba-copier-template/pull/401#issuecomment-1778858811 'odoo-pre-commit-hooks' hooks are added.

Related info: https://github.com/OCA/odoo-pre-commit-hooks/tree/main?tab=readme-ov-file#usage-pre-commit-configyaml