### PR TITLE
[FIX] The SMTP domain should prefix `smtp`

### DIFF
--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -51,7 +51,7 @@ services:
 
   smtpreal:
     image: ghcr.io/docker-mailserver/docker-mailserver:{{ smtp_relay_version }}
-    hostname: "{{ smtp_canonical_default }}"
+    hostname: "smtp.{{ smtp_canonical_default }}"
     stop_grace_period: 1m
     volumes:
       - mailconfig:/tmp/docker-mailserver:z


### PR DESCRIPTION
If not, mails are not delivered.

@Tecnativa 