### PR TITLE
fix(backup): convert odoo regex extensions

### DIFF
--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -92,7 +92,7 @@ services:
     init: true
     environment:
       DB_VERSION: "{{ postgres_version or 'latest' }}"
-      DBS_TO_INCLUDE: "{{ odoo_dbfilter }}"
+      DBS_TO_INCLUDE: "{{ odoo_dbfilter | replace('$', '$$') | replace('%d', '.*') | replace('%h', '.*') }}"
       DST: "{{ backup_dst }}"
       {%- if smtp_relay_host %}
       EMAIL_FROM: "{{ backup_email_from }}"

--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -21,7 +21,7 @@ services:
       - .docker/odoo.env
       - .docker/db-access.env
     environment:
-      DB_FILTER: "{{ odoo_dbfilter }}"
+      DB_FILTER: "{{ odoo_dbfilter | replace('$', '$$') }}"
       DOODBA_ENVIRONMENT: "${DOODBA_ENVIRONMENT-prod}"
       INITIAL_LANG: "{{ odoo_initial_lang }}"
       {%- if smtp_relay_host %}


### PR DESCRIPTION
The backup image [accepts a regexp on `DBS_TO_INCLUDE`][1]. But [Odoo uses a regexp with custom extensions][2] (`%h` and `%d`).

If you use any of those extensions, the backup jobrunner will fail with `CalledProcessError`.

Additionally, regexps usually contain a `$` symbol, which [needs to be escaped for docker-compose][3].

[1]: https://github.com/Tecnativa/docker-duplicity#dbs_to_includeexclude
[2]: https://www.odoo.com/documentation/16.0/developer/reference/cli.html#cmdoption-odoo-bin-db-filter
[3]: https://docs.docker.com/compose/compose-file/compose-file-v2/#variable-substitution

BREAKING CHANGE: if your dbfilter contained `$$` previously, to do that escaping yourself, you will have to convert it to a single `$`

@moduon MT-4191