### PR TITLE
fix(ruff): less pedantic max-line-length config

### DIFF
--- a/.ruff.toml.jinja
+++ b/.ruff.toml.jinja
@@ -1,4 +1,10 @@
-target-version = "py310"
+target-version = {% if odoo_version < 14 -%}
+"py37"
+{%- elif odoo_version < 16 %}
+"py38"
+{%- else %}
+"py310"
+{%- endif %}
 fix = true
 cache-dir = "~/.cache/ruff"
 

--- a/.ruff.toml.jinja
+++ b/.ruff.toml.jinja
@@ -12,6 +12,9 @@ extend-select = [
 ]
 exclude = ["setup/*"]
 
+[lint.pycodestyle]
+max-line-length = 120
+
 [format]
 exclude = ["setup/*"]
 


### PR DESCRIPTION
Until template v5.x, we just used Black, which didn't cry about line
length. After an upgrade to the latest template, there are a lot of E501
errors that are not really helpful. The autoformatter will fix most
cases, but sometimes having a longer line is more readable.

Here, I'm increasing the limit to 120 characters. If it's still too low,
we can just remove E501 from the list of errors.

@moduon MT-4544 @emiliopascual
