### PR TITLE
fix(ruff): consider odoo version to establish python target version

### DIFF
--- a/.ruff.toml.jinja
+++ b/.ruff.toml.jinja
@@ -1,4 +1,4 @@
-target-version = "py310"
+target-version = {% if odoo_version < 14 %}"py37"{% elif odoo_version < 16 %}"py38"{% else %}"py310"{% endif %}
 fix = true
 cache-dir = "~/.cache/ruff"
 


### PR DESCRIPTION
@moduon MT-4544

These versions match the ones in the dockerfiles of doodba. Well, some of them are older than 3.7, but ruff doesn't support that, so by putting py37 on those, we get closer to something useful.