### PR TITLE
fix(prettier): rollback to working version

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -60,14 +60,16 @@ repos:
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.2
+    # HACK https://github.com/prettier/prettier/issues/15696
+    rev: v2.7.1
     hooks:
       - id: prettier
         name: prettier + plugin-xml
+        args: [--plugin=@prettier/plugin-xml]
         additional_dependencies:
           # HACK https://github.com/prettier/pre-commit/issues/16#issuecomment-713474520
-          - prettier@3.0.2
-          - "@prettier/plugin-xml@v3.2.0"
+          - prettier@2.7.1
+          - "@prettier/plugin-xml@v2.2.0"
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:


### PR DESCRIPTION
As you can see reported in https://github.com/prettier/prettier/issues/15696, prettier 3.x won't work with plugins under the context of pre-commit. In practice, this means for us that XML won't get auto-formatted.

Pinning latest working combination.

@moduon MT-5455