### PR TITLE
[IMP] Try use docker compose command v2 by default

### DIFF
--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -47,7 +47,7 @@ ODOO_VERSION = float(
     ]["args"]["ODOO_VERSION"]
 )
 DOCKER_COMPOSE_CMD = (
-    shutil.which("docker-compose") or f"{shutil.which('docker')} compose"
+    f"{shutil.which('docker')} compose" or shutil.which("docker-compose")
 )
 
 _logger = getLogger(__name__)


### PR DESCRIPTION
cc @Tecnativa

To avoid error when you start an instance and try to start twice 
```
container.image_config['ContainerConfig'].get('Volumes') or {}
    KeyError: 'ContainerConfig'
```

ping @josep-tecnativa @carlosdauden 