### PR TITLE
Update inverseproxy template, version bump traefik to 1.7

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -189,7 +189,7 @@ version: "2.1"
 
 services:
   proxy:
-    image: docker.io/traefik:1.6-alpine
+    image: docker.io/traefik:1.7-alpine
     networks:
       shared:
       private:


### PR DESCRIPTION
Bumping to traefik version 1.7 Solves:
`Provider connection error Error response from daemon: {"message":"client version 1.21 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version"}`
as it updates the docker API version to 1.24.

This error occurs when running the inverseproxy on a fresh installed ubuntu LTS machine.
Which uses a recent docker version. 