### PR TITLE
[IMP] Add Traefik v2 and Traefik v3 documentation

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -189,7 +189,7 @@ version: "2.1"
 
 services:
   proxy:
-    image: docker.io/traefik:1.6-alpine
+    image: docker.io/traefik:1.7-alpine
     networks:
       shared:
       private:
@@ -257,7 +257,93 @@ volumes:
 <details>
 <summary>Traefik v2 docker compose</summary>
 
-![TODO](https://media.giphy.com/media/26gspO0c90QDHEQQ8/giphy.gif)
+```yaml
+version: "2.4"
+services:
+  proxy:
+    image: traefik:2.4
+    networks:
+      shared:
+        aliases: []
+      private:
+      public:
+    volumes:
+      - acme:/etc/traefik/acme:rw,Z
+    ports:
+      - 80:80
+      - 443:443
+    depends_on:
+      - dockersocket
+    restart: unless-stopped
+    tty: true
+    command:
+      - "--entrypoints.web-insecure.address=:80"
+      - "--entrypoints.web-main.transport.respondingTimeouts.idleTimeout=60s"
+      - "--entrypoints.web-main.http.middlewares=global-error-502@docker"
+      - "--log.level=info"
+      - "--providers.docker.endpoint=http://dockersocket:2375"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.network=inverseproxy_shared"
+      - "--providers.docker=true"
+      - "--entrypoints.web-main.address=:443"
+      - "--entrypoints.web-main.http.tls.certResolver=letsencrypt"
+      - "--certificatesresolvers.letsencrypt.acme.caserver=https://acme-v02.api.letsencrypt.org/directory"
+      - "--certificatesresolvers.letsencrypt.acme.email=alerts@example.com"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/etc/traefik/acme/acme-v2.json"
+      - "--entrypoints.web-insecure.http.redirections.entryPoint.to=web-main"
+      - "--entrypoints.web-insecure.http.redirections.entryPoint.scheme=https"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web-insecure"
+  dockersocket:
+    image: tecnativa/docker-socket-proxy
+    privileged: true
+    networks:
+      private:
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    environment:
+      CONTAINERS: 1
+      NETWORKS: 1
+      SERVICES: 1
+      SWARM: 1
+      TASKS: 1
+    restart: unless-stopped
+  error-handling:
+    image: nginx:alpine
+    restart: unless-stopped
+    networks:
+      - shared
+    volumes:
+      - error-handling-config:/etc/nginx/conf.d/
+      - error-handling-data:/usr/share/nginx/html/
+    labels:
+      traefik.docker.network: inverseproxy_shared
+      traefik.enable: "true"
+      traefik.http.routers.error-handling.rule: HostRegexp(`{any:.+}`)
+      traefik.http.routers.error-handling.entrypoints: web-main
+      traefik.http.routers.error-handling.priority: 1
+      traefik.http.routers.error-handling.service: global-error-handler
+      traefik.http.routers.error-handling.middlewares: global-error-502
+      traefik.http.middlewares.global-error-502.errors.status: 502
+      traefik.http.middlewares.global-error-502.errors.service: global-error-handler
+      traefik.http.middlewares.global-error-502.errors.query: "/{status}.html"
+      traefik.http.services.global-error-handler.loadbalancer.server.port: 80
+networks:
+  shared:
+    internal: true
+    driver_opts:
+      encrypted: 1
+  private:
+    internal: true
+    driver_opts:
+      encrypted: 1
+  public:
+    driver_opts:
+      encrypted: 1
+volumes:
+  acme:
+  error-handling-config:
+  error-handling-data:
+```
 
 </details>
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -347,6 +347,105 @@ volumes:
 
 </details>
 
+<details>
+<summary>Traefik v3 docker compose</summary>
+
+```yaml
+version: "2.4"
+services:
+  proxy:
+    image: traefik:3.0
+    networks:
+      shared:
+        aliases: []
+      private:
+      public:
+    volumes:
+      - acme:/etc/traefik/acme:rw,Z
+    ports:
+      - 80:80
+      - 443:443
+      - 5432:5432 # Add this port for direct database access
+    depends_on:
+      - dockersocket
+    restart: unless-stopped
+    environment:
+      AWS_ACCESS_KEY_ID: ""
+      AWS_SECRET_ACCESS_KEY: ""
+      LEGO_EXPERIMENTAL_CNAME_SUPPORT: "true"
+    tty: true
+    command:
+      - "--entrypoints.web-insecure.address=:80"
+      - "--entrypoints.web-main.transport.respondingTimeouts.idleTimeout=60s"
+      - "--entrypoints.web-main.http.middlewares=global-error-502@docker"
+      - "--log.level=info"
+      - "--providers.docker.endpoint=http://dockersocket:2375"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.network=inverseproxy_shared"
+      - "--providers.docker=true"
+      - "--entrypoints.web-main.address=:443"
+      - "--entrypoints.web-main.http.tls.certResolver=letsencrypt"
+      - "--certificatesresolvers.letsencrypt.acme.caserver=https://acme-v02.api.letsencrypt.org/directory"
+      - "--certificatesresolvers.letsencrypt.acme.email=alerts@example.com"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/etc/traefik/acme/acme-v2.json"
+      - "--entrypoints.web-insecure.http.redirections.entryPoint.to=web-main"
+      - "--entrypoints.web-insecure.http.redirections.entryPoint.scheme=https"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web-insecure"
+      - "--entrypoints.postgres-entrypoint.address=:5432" # Define entrypoint for PostgreSQL for direct database access
+  dockersocket:
+    image: tecnativa/docker-socket-proxy
+    privileged: true
+    networks:
+      private:
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    environment:
+      CONTAINERS: 1
+      NETWORKS: 1
+      SERVICES: 1
+      SWARM: 1
+      TASKS: 1
+    restart: unless-stopped
+  error-handling:
+    image: nginx:alpine
+    restart: unless-stopped
+    networks:
+      - shared
+    volumes:
+      - error-handling-config:/etc/nginx/conf.d/
+      - error-handling-data:/usr/share/nginx/html/
+    labels:
+      traefik.docker.network: inverseproxy_shared
+      traefik.enable: "true"
+      traefik.http.routers.error-handling.rule: HostRegexp(`{any:.+}`)
+      traefik.http.routers.error-handling.entrypoints: web-main
+      traefik.http.routers.error-handling.priority: 1
+      traefik.http.routers.error-handling.service: global-error-handler
+      traefik.http.routers.error-handling.middlewares: global-error-502
+      traefik.http.middlewares.global-error-502.errors.status: 502
+      traefik.http.middlewares.global-error-502.errors.service: global-error-handler
+      traefik.http.middlewares.global-error-502.errors.query: "/{status}.html"
+      traefik.http.services.global-error-handler.loadbalancer.server.port: 80
+networks:
+  shared:
+    internal: true
+    driver_opts:
+      encrypted: 1
+  private:
+    internal: true
+    driver_opts:
+      encrypted: 1
+  public:
+    driver_opts:
+      encrypted: 1
+volumes:
+  acme:
+  error-handling-config:
+  error-handling-data:
+```
+
+</details>
+
 Then boot it up with:
 
 ```bash


### PR DESCRIPTION
Adding Traefik v2 and Traefik v3 configuration example.
In Traefik v3 is added postgres-entrypoint to be able to use feature developed on https://github.com/Tecnativa/doodba-copier-template/pull/479