### PR TITLE
fix(queue_job): out-of-the-box support in test environments

### DIFF
--- a/test.yaml.jinja
+++ b/test.yaml.jinja
@@ -19,6 +19,8 @@ services:
       WITHOUT_DEMO: "${DOODBA_WITHOUT_DEMO-all}"
       SMTP_PORT: "1025"
       SMTP_SERVER: smtplocal
+      # Just in case you use queue_job
+      ODOO_QUEUE_JOB_CHANNELS: "root:1"
     restart: unless-stopped
     {%- if domains_test %}
     hostname: {{ macros.first_main_domain(domains_test)|tojson }}
@@ -48,7 +50,7 @@ services:
     {%- endif %}
     command:
       - odoo
-      - --workers=2
+      - --workers=3
       - --max-cron-threads=1
 
   {% if postgres_version -%}


### PR DESCRIPTION
When you use queue_job, it is common to add some configuration to it.

The canonical way to do that with doodba would be to put a file in some path such as `odoo/custom/conf.d/queue_job.conf` and contents like these:

```ini
[options]
(...)
workers = 6
server_wide_modules = base,web,queue_job

(...)
[queue_job]
channels = root:3
```

However, in that case, the file would be used too by a test environment.

Test environments have 2 workers hardcoded, to save computational power for the production instance: https://github.com/Tecnativa/doodba-copier-template/blob/e2f4efdab336d5cd32c327a007983011e1e4edbb/test.yaml.jinja#L50

However, if you configure 2 workers with `channels = root:3`, you're doomed. Any delayed action in a test environment will block the server. At least, if the amount of delayed actions in batch is more than the current workers.

I'm adding docs to queue_job in https://github.com/OCA/queue/pull/650 to make this behavior clear. Also, here I'm adding an environment variable that will be harmless in test environments without `queue_job`, but will provide a sane default for those that use it.

@moduon MT-6106