### PR TITLE
[IMP] New parameter 'tags' to enable filtering tests according to tags.

### DIFF
--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -748,6 +748,7 @@ def test(
     cur_file=None,
     mode="init",
     db_filter="^devel$",
+    tags=None,
 ):
     """Run Odoo tests
 
@@ -793,7 +794,10 @@ def test(
         # Limit tests to explicit list
         # Filter spec format (comma-separated)
         # [-][tag][/module][:class][.method]
-        odoo_command.extend(["--test-tags", f"/{',/'.join(modules_list)}"])
+        test_tags = f"/{',/'.join(modules_list)}"
+        if tags:
+            test_tags = tags
+        odoo_command.extend(["--test-tags", test_tags])
     if debugpy:
         _test_in_debug_mode(c, odoo_command)
     else:


### PR DESCRIPTION
When tags are specified, the `module_list` is ignored because Odoo executes tests with an OR condition, meaning all tests will be executed. See examples below.

Execute only test with tags `MyTag`
`invoke test -m MyModule --tags=MyTag`

Execute only a function called test_my_custom(Note use . to referral to function) 
`invoke test -m MyModule --tags=.test_my_custom`

More examples
https://www.odoo.com/documentation/17.0/es/developer/reference/backend/testing.html#examples

TODO:

- [ ] add test


@pedrobaeza could you take a look, what do you think?