### PR TITLE
[IMP] doodba-copier-template: domains_prod and domains_test

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -214,8 +214,12 @@ gitlab_url:
 domains_prod:
   type: yaml
   multiline: true
-  default: {}
+  default: null
   placeholder: |
+    - hosts:
+        - www.main.com
+        - shop.main.com
+  examples: |
     # Main domains, with TLS and cert resolved with "letsencrypt" resolver
     - hosts:
         - www.main.com
@@ -270,8 +274,12 @@ domains_prod:
 domains_test:
   type: yaml
   multiline: true
-  default: {}
+  default: null
   placeholder: |
+    - hosts:
+        - demo1.main.com
+        - demo2.main.com
+  examples: |
     # Main domains, with TLS and cert resolved with "letsencrypt" resolver
     - hosts:
         - demo1.main.com


### PR DESCRIPTION
Answering the copier questions, I was misleaded by the `domain_prod` and `domain_test` default value `{}` when a custom value should be a list.

I suggest default value `null`. When the user deletes the default value, a simple placeholder will show up.
