### PR TITLE
[ADD] Feature to expose database

### DIFF
--- a/_traefik3_paths_labels.yml.jinja
+++ b/_traefik3_paths_labels.yml.jinja
@@ -42,6 +42,16 @@
   {%- endif %}
 {%- endmacro %}
 
+{%- macro domains_rule_sni(domain_group) -%}
+  {%- for host in domain_group.hosts -%}
+    HostSNI(`{{ host }}`)
+    {%- if not loop.last -%}
+      ||
+    {%- endif -%}
+  {%- endfor -%}
+{%- endmacro %}
+
+
 {%- macro key(project_name, odoo_version, suffix) %}
   {{- '%s-%.1f-%s'|format(project_name, odoo_version, suffix)|replace('.', '-') }}
 {%- endmacro %}
@@ -210,7 +220,10 @@
 
 {%- macro database(domain_groups_list, cidr_whitelist, key, port, project_name) %}
       {#- Service #}
+      traefik.tcp.routers.{{ key }}-database.entrypoints: postgres-entrypoint
       traefik.tcp.services.{{ key }}-database.loadbalancer.server.port: 5432
+      traefik.tcp.routers.{{ key }}-database.tls: "true"
+      traefik.tcp.routers.{{ key }}-database.tls.certResolver: letsencrypt
 
       {%- if cidr_whitelist %}
       {#- Declare whitelist middleware #}
@@ -220,23 +233,12 @@
         {%- endfor %}
       {%- endif %}
 
-      {%- call(domain_group) macros.domains_loop_grouped(domain_groups_list) %}
+      {#- Apply rule to the first element in domain_groups_list #}
+      {%- set first_domain_group = domain_groups_list[0] %}
+      traefik.tcp.routers.{{ key }}-database.rule: {{ domains_rule_sni(first_domain_group) }}
       {#- Remember basic middlewares for this domain group #}
       {%- set _ns = namespace(basic_middlewares=[]) -%}
       {%- if cidr_whitelist %}
         {%- set _ns.basic_middlewares = _ns.basic_middlewares + ["whitelist"] %}
       {%- endif %}
-
-      {#- database router #}
-      {{-
-        router_tcp(
-          domain_group=domain_group,
-          key=key,
-          suffix="database",
-          service="database",
-          middlewares=_ns.basic_middlewares,
-          port=port,
-        )
-      }}
-      {%- endcall %}
 {%- endmacro %}

--- a/copier.yml
+++ b/copier.yml
@@ -414,7 +414,7 @@ postgres_exposed:
 postgres_exposed_port:
   default: 5432
   type: int
-  when: &db_exposed "{{ postgres_exposed and true }}"
+  when: &db_exposed "{{ postgres_exposed and traefik_version != 3 }}"
   help: >-
     Indicate the port to connect to the database.
 

--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -94,7 +94,7 @@ services:
     labels:
       traefik.enable: "true"
       traefik.docker.network: "inverseproxy_shared"
-      {{- traefik2_labels.database(
+      {{- traefik3_labels_2.database(
         domains_prod,
         postgres_cidr_whitelist,
         _key,

--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -88,6 +88,7 @@ services:
       - .docker/db-creation.env
     restart: unless-stopped
     {%- if postgres_exposed %}
+    {%- if traefik_version == 3 %}
     networks:
       default:
       inverseproxy_shared:
@@ -101,6 +102,10 @@ services:
         postgres_exposed_port,
         project_name,
       ) }}
+    {%- else %}
+    ports:
+      - "{{ postgres_exposed_port }}:5432"
+    {%- endif %}
     {%- endif %}
   {%- endif %}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,7 +155,7 @@ def traefik_host(request):
     docker = DockerClient()
     if request.param == "3":
         traefik_container = docker.run(
-            "traefik:v3.0",
+            "traefik:v3.1.2",
             detach=True,
             privileged=True,
             networks=["inverseproxy_shared"],


### PR DESCRIPTION
Since Traefik 3 is avaliable on Doodba Copier Template, we can configure with our template, a postgres exposed database. This is only working on Traefik 3.

- [x] Correct when serveral domains, HostSNI duplicated map key traefik label.