### PR TITLE
[FIX] Pre-commit problems for odoo versions with python < 3.7

### DIFF
--- a/.flake8.jinja
+++ b/.flake8.jinja
@@ -1,0 +1,12 @@
+[flake8]
+max-line-length = 88
+max-complexity = 16
+# B = bugbear
+# B9 = bugbear opinionated (incl line length)
+select = C,E,F,W,B,B9
+# E203: whitespace before ':' (black behaviour)
+# E501: flake8 line length (covered by bugbear B950)
+# W503: line break before binary operator (black behaviour)
+ignore = E203,E501,W503,B907
+per-file-ignores=
+    __init__.py:F401

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -53,12 +53,45 @@ repos:
       - id: oca-checks-po
         args: ["--fix"]
   {% endif -%}
+  {% if odoo_version >= 13 -%}
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.3
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
+  {% else -%}
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+        additional_dependencies: ["click<=8.1.7"]
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort except __init__.py
+        args: [--settings, .]
+        exclude: /__init__\.py$
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        name: flake8 except __init__.py, __manifest__.py
+        args: ["--extend-ignore=B023"]
+        exclude: /__(?:init|manifest)__\.py$
+        additional_dependencies: ["flake8-bugbear==23.7.10", "importlib-metadata<=6.8.0"]
+      - id: flake8
+        name: flake8 only __init__.py
+        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
+        files: /__init__\.py$
+        additional_dependencies: ["flake8-bugbear==23.7.10", "importlib-metadata<=6.8.0"]
+      - id: flake8
+        name: flake8 only __manifest__.py
+        args: ["--extend-ignore=B018"] # ignore found useless expression in __manifest__.py
+        files: /__manifest__\.py$
+        additional_dependencies: ["flake8-bugbear==23.7.10", "importlib-metadata<=6.8.0"]
+  {% endif -%}
   - repo: https://github.com/pre-commit/mirrors-prettier
     # HACK https://github.com/prettier/prettier/issues/15696
     rev: v2.7.1

--- a/isort.cfg.jinja
+++ b/isort.cfg.jinja
@@ -1,0 +1,13 @@
+[settings]
+; see https://github.com/psf/black
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+combine_as_imports=True
+use_parentheses=True
+line_length=88
+known_odoo=odoo
+known_odoo_addons=odoo.addons
+sections=FUTURE,STDLIB,THIRDPARTY,ODOO,ODOO_ADDONS,FIRSTPARTY,LOCALFOLDER
+default_section=THIRDPARTY
+ensure_newline_before_comments = True


### PR DESCRIPTION
CC  @Tecnativa TT50985
As ruff is not compatible with Python versions below 3.7, the pre-commit is causing problems in Odoo versions below 13.0.

- [x] Test pre-commit on odoo < 13.0 scaffolding
- [x] Test pre-commit on odoo >= 13.0 scaffolding to make sure that it  keeps using ruff instead of flake8
