### PR TITLE
Update faq: update --force is deprecated

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -408,7 +408,7 @@ pre-commit reformat your files in next commit, and commit again.
 Quick dirty recipe:
 
 ```bash
-copier --force update
+copier update --trust
 git add .
 pre-commit run
 git add .


### PR DESCRIPTION
as of https://github.com/copier-org/copier/commit/6dde037423da28940abeed081d978af621c4ac38 the `--force` flag is removed. 

It results in: Error: Unknown switch --force