### PR TITLE
[ADD] pg17 support

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -361,7 +361,7 @@ cidr_whitelist:
     ⚠️ It must be a list. And this is only supported if you deploy with Traefik 2+.
 
 postgres_version:
-  default: "16"
+  default: "17"
   help: >-
     Which PostgreSQL version do you want to deploy? (Recommended: for new instances
     always use the latest version. Version 9.6 has no backup support.)
@@ -375,6 +375,7 @@ postgres_version:
     "14": "14"
     "15": "15"
     "16": "16"
+    "17": "17"
   validator: >-
     {% if postgres_version|int > 0 %} {% if (odoo_version >= 16.0 and
     postgres_version|int < 12) or (odoo_version >= 14.0 and postgres_version|int < 10)


### PR DESCRIPTION
The latest Odoo Enterprise upgrades have begun utilizing PostgreSQL 17. Therefore, I believe it would be beneficial to incorporate support for PostgreSQL 17 here as well.

```shell
❯ head -n 10 odoo/auto/upgraded.dump/toc.dat
7GDMP
|
db_xxxxxxx 17.1 (Ubuntu 17.1-1.pgdg20.04+1) 17.0 (Ubuntu 17.0-1.pgdg20.04+1)AP<0ENCODINENCODINGSET client_encoding = 'UTF8';
falseQ<00
STDSTRINGS
STDSTRINGS(SET standard_conforming_strings = 'on';
falseR<00
SEARCHPATH
SEARCHPATH8SELECT pg_catalog.set_config('search_path', '', false);
falseS<126216394
```