### PR TITLE
fix: allow odoo to find Postgres in production (‼️)

### DIFF
--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -93,12 +93,12 @@ services:
     env_file:
       - .docker/db-creation.env
     restart: unless-stopped
-    {%- if postgres_exposed %}
-    {%- if traefik_version == 3 %}
     networks:
       default:
         aliases:
             - "{{ _key }}-db"
+    {%- if postgres_exposed %}
+    {%- if traefik_version == 3 %}
       inverseproxy_shared:
     labels:
       traefik.enable: "true"


### PR DESCRIPTION
If you deploy Odoo with `postgres_exposed=false`, your production server will go down without this fix. Odoo won't be able to find Postgres.

@moduon MT-9318