### PR TITLE
[FIX] update deprecations for new vs code

### DIFF
--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -224,7 +224,7 @@ def write_code_workspace_file(c, cw_path=None):
             "search.followSymlinks": False,
             "search.useIgnoreFiles": False,
             # Language-specific configurations
-            "[python]": {"editor.defaultFormatter": "ms-python.black-formatter"},
+            "[python]": {"editor.defaultFormatter": "ms-python.python"},
             "[json]": {"editor.defaultFormatter": "esbenp.prettier-vscode"},
             "[jsonc]": {"editor.defaultFormatter": "esbenp.prettier-vscode"},
             "[markdown]": {"editor.defaultFormatter": "esbenp.prettier-vscode"},
@@ -235,12 +235,13 @@ def write_code_workspace_file(c, cw_path=None):
     # Launch configurations
     debugpy_configuration = {
         "name": "Attach Python debugger to running container",
-        "type": "python",
+        "type": "debugpy",
         "request": "attach",
         "pathMappings": [],
-        "port": int(ODOO_VERSION) * 1000 + 899,
-        # HACK https://github.com/microsoft/vscode-python/issues/14820
-        "host": "0.0.0.0",
+        "connect": {
+            "host": "0.0.0.0",
+            "port": int(ODOO_VERSION) * 1000 + 899,
+        },
     }
     firefox_configuration = {
         "type": "firefox",
@@ -262,6 +263,7 @@ def write_code_workspace_file(c, cw_path=None):
         "url": f"http://localhost:{ODOO_VERSION:.0f}069/?debug=assets",
         "skipFiles": ["**/lib/**"],
         "trace": True,
+        "runtimeArgs": ["--auto-reload=true"],
         "pathMapping": {},
     }
     if chrome_executable:
@@ -271,19 +273,19 @@ def write_code_workspace_file(c, cw_path=None):
         "compounds": [
             {
                 "name": "Start Odoo and debug Python",
-                "configurations": ["Attach Python debugger to running container"],
+                "configurations": [],
                 "preLaunchTask": "Start Odoo in debug mode",
             },
             {
                 "name": "Test and debug current module",
-                "configurations": ["Attach Python debugger to running container"],
+                "configurations": [],
                 "preLaunchTask": "Run Odoo Tests in debug mode for current module",
                 "internalConsoleOptions": "openOnSessionStart",
             },
         ],
         "configurations": [
             debugpy_configuration,
-            firefox_configuration,
+            # firefox_configuration,
             chrome_configuration,
         ],
     }


### PR DESCRIPTION
The new version of VS Code is deprecating Firefox debugger, and some object names so I updated them.
I only comment on the firefox_configutations as it may be needed in the future, who knows!

As we see there is no any error or warning in the ``PROBLEMS`` section in the terminal window.

![Screenshot from 2025-03-10 03-56-23](https://github.com/user-attachments/assets/58ced2e1-9981-423c-8b0f-873c15871c97)
