### PR TITLE
[FIX] Remove ODOO_BUS_PUBLIC_SAMESITE_WS by default to avoid AccessDenied in WebSocket

### DIFF
--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -24,9 +24,6 @@ services:
       DB_FILTER: "{{ odoo_dbfilter | replace('$', '$$') }}"
       DOODBA_ENVIRONMENT: "${DOODBA_ENVIRONMENT-prod}"
       INITIAL_LANG: "{{ odoo_initial_lang }}"
-      {%- if odoo_version >= 16.0 %}
-      ODOO_BUS_PUBLIC_SAMESITE_WS: 1
-      {%- endif %}
       {%- if smtp_relay_host %}
       SMTP_SERVER: smtplocal
       {%- endif %}

--- a/test.yaml.jinja
+++ b/test.yaml.jinja
@@ -15,9 +15,6 @@ services:
       - .docker/db-access.env
     environment:
       DOODBA_ENVIRONMENT: "${DOODBA_ENVIRONMENT-test}"
-      {%- if odoo_version >= 16.0 %}
-      ODOO_BUS_PUBLIC_SAMESITE_WS: 1
-      {%- endif %}
       # To install demo data export DOODBA_WITHOUT_DEMO=false
       WITHOUT_DEMO: "${DOODBA_WITHOUT_DEMO-all}"
       SMTP_PORT: "1025"


### PR DESCRIPTION
Defining ODOO_BUS_PUBLIC_SAMESITE_WS triggers an AccessDenied error on WebSocket connections. Removing this variable by default resolves the issue:
```
ESC[1;31mESC[1;49mERROR ESC[0m prod odoo.addons.bus.websocket: Exception occurred during websocket request handling 
...
odoo.exceptions.AccessDenied: Access Denied
```
While the exact reason isn't fully determined, eliminating the variable prevents the error without side effects.

This PR reverts https://github.com/Tecnativa/doodba-copier-template/pull/513

CC @Tecnativa TT55574
ping @yajo 