### PR TITLE
[FIX] don't recomment obsolete extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,10 +7,9 @@
     "esbenp.prettier-vscode",
     "firefox-devtools.vscode-firefox-debug",
     "mrorz.language-gettext",
-    "ms-azuretools.vscode-docker",
+    "ms-azuretools.vscode-containers",
     "ms-python.black-formatter",
     "ms-python.python",
-    "msjsdiag.debugger-for-chrome",
     "redhat.vscode-xml",
     "samuelcolvin.jinjahtml"
   ]


### PR DESCRIPTION
1. [msjsdiag.debugger-for-chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) is deprecated
2. [ms-azuretools.vscode-containers](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) is replaced by[ container tools](https://techcommunity.microsoft.com/blog/AppsonAzureBlog/major-updates-to-vs-code-docker-introducing-container-tools/4400609) 
@Tecnativa @josep-tecnativa