### PR TITLE
[IMP] Add suppor for Pydevd/Pycharm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@
 /doodba.*.code-workspace
 /src
 .idea/*
+# Ignore local dependencies
+/odoo/custom/dependencies/*-local.*
 
 # Project-specific docker configurations
 /.docker/

--- a/template/devel.yaml.jinja
+++ b/template/devel.yaml.jinja
@@ -40,6 +40,7 @@ services:
       INITIAL_LANG: "{{ odoo_initial_lang }}"
       LIST_DB: "true"
       DEBUGPY_ENABLE: "${DOODBA_DEBUGPY_ENABLE:-0}"
+      PYDEVD_ENABLE: "${DOODBA_PYDEVD_ENABLE:-0}"
       PGDATABASE: &dbname devel
       PYDEVD_RESOLVE_SYMLINKS: 1
       PYTHONDONTWRITEBYTECODE: 1

--- a/template/tasks_downstream.py
+++ b/template/tasks_downstream.py
@@ -523,14 +523,22 @@ def lint(c, verbose=False):
 
 
 @task()
-def start(c, detach=True, debugpy=False, _reload=True, port_prefix=0):
+def start(
+    c,
+    detach=True,
+    debugpy=False,
+    _reload=True,
+    port_prefix=0,
+    pydevd=False,
+):
     """Start environment."""
     cmd = DOCKER_COMPOSE_CMD + " up"
+    disable_reload = any([not _reload, debugpy, pydevd])
     with tempfile.NamedTemporaryFile(
         mode="w",
         suffix=".yaml",
     ) as tmp_docker_compose_file:
-        if debugpy or not _reload:
+        if disable_reload:
             # Remove auto-reload
             cmd = (
                 DOCKER_COMPOSE_CMD + " -f docker-compose.yml "
@@ -543,7 +551,11 @@ def start(c, detach=True, debugpy=False, _reload=True, port_prefix=0):
         if detach:
             cmd += " --detach"
         with c.cd(str(PROJECT_ROOT)):
-            env = UID_ENV | {"DOODBA_DEBUGPY_ENABLE": str(int(debugpy))}
+            env = dict(
+                UID_ENV,
+                DOODBA_DEBUGPY_ENABLE=str(int(debugpy)),
+                DOODBA_PYDEVD_ENABLE=str(int(pydevd)),
+            )
             if port_prefix:
                 env["PORT_PREFIX"] = str(port_prefix)
             result = c.run(

--- a/template/tasks_downstream.py
+++ b/template/tasks_downstream.py
@@ -13,12 +13,14 @@ import stat
 import subprocess
 import tempfile
 import time
+import xml.dom.minidom
 from datetime import datetime
 from glob import iglob
 from itertools import chain
 from logging import getLogger
 from pathlib import Path
 from shutil import which
+from xml.etree.ElementTree import Element, SubElement, tostring
 
 from invoke import exceptions, task
 
@@ -157,6 +159,105 @@ def _modules_installed(c, modules_list, dbname="devel"):
     )
     res = c.run(cmd, hide=True, warn=True)
     return set(filter(None, res.stdout.splitlines()))
+
+
+@task
+def generate_idea_conf(c):
+    """Generate .idea to be able to use pycharm debugger."""
+    run_config_dir = Path(".idea/runConfigurations")
+    run_config_dir.mkdir(parents=True, exist_ok=True)
+    config_filename = "debug_odoo.xml"
+    config_file = run_config_dir / config_filename
+    component = Element("component", {"name": "ProjectRunConfigurationManager"})
+    configuration = SubElement(
+        component,
+        "configuration",
+        {
+            "name": "Debug Odoo",
+            "type": "PyRemoteDebugConfigurationType",
+            "factoryName": "Python Remote Debug",
+        },
+    )
+    SubElement(configuration, "module", {"name": PROJECT_ROOT.name})
+    SubElement(configuration, "option", {"name": "PORT", "value": "6988"})
+    SubElement(configuration, "option", {"name": "HOST", "value": "localhost"})
+    path_mapping_settings = SubElement(configuration, "PathMappingSettings")
+    option = SubElement(path_mapping_settings, "option", {"name": "pathMappings"})
+    mapping_list = SubElement(option, "list")
+    full_path = SRC_PATH.resolve()
+    for subrepo in SRC_PATH.glob("*"):
+        if not subrepo.is_dir():
+            continue
+        # Check if subrepo is itself a doodba-copier project
+        is_doodba_subproject = False
+        answers_file = subrepo / ".copier-answers.yml"
+        if answers_file.is_file():
+            with answers_file.open() as f:
+                answers = yaml.safe_load(f) or {}
+            if "Tecnativa/doodba-copier-template" in answers.get("_src_path", ""):
+                is_doodba_subproject = True
+        private_dir = subrepo / "odoo" / "custom" / "src" / "private"
+        # Default scanning approach (1-level + addons/* + private/*)
+        for addon in chain(
+            subrepo.glob("*"),
+            subrepo.glob("addons/*"),
+            private_dir.glob("*"),
+        ):
+            if (addon / "__manifest__.py").is_file() or (
+                addon / "__openerp__.py"
+            ).is_file():
+                if is_doodba_subproject:
+                    local_path = "%s/%s/odoo/custom/src/private/%s" % (  # noqa: UP031
+                        full_path,
+                        subrepo.name,
+                        addon.name,
+                    )
+                elif subrepo.name == "odoo":
+                    local_path = "%s/%s/addons/%s" % (  # noqa: UP031
+                        full_path,
+                        subrepo.name,
+                        addon.name,
+                    )
+                else:
+                    local_path = "%s/%s/%s" % (  # noqa: UP031
+                        full_path,
+                        subrepo.name,
+                        addon.name,
+                    )
+                SubElement(
+                    mapping_list,
+                    "mapping",
+                    {
+                        "local-root": local_path,
+                        "remote-root": f"/opt/odoo/auto/addons/{addon.name}",
+                    },
+                )
+    SubElement(
+        mapping_list,
+        "mapping",
+        {
+            "local-root": "%s/odoo/odoo-bin" % full_path,  # noqa: UP031
+            "remote-root": "/usr/local/bin/odoo",
+        },
+    )
+    SubElement(
+        mapping_list,
+        "mapping",
+        {
+            "local-root": "%s/odoo" % full_path,  # noqa: UP031
+            "remote-root": "/opt/odoo/custom/src/odoo",
+        },
+    )
+    SubElement(configuration, "option", {"name": "REDIRECT_OUTPUT", "value": "true"})
+    SubElement(
+        configuration, "option", {"name": "SUSPEND_AFTER_CONNECT", "value": "true"}
+    )
+    SubElement(configuration, "method", {"v": "2"})
+    xml_str = tostring(component, "utf-8")
+    parsed = xml.dom.minidom.parseString(xml_str)
+    pretty_xml = parsed.toprettyxml(indent="  ")
+    with open(config_file, "w", encoding="utf-8") as f:
+        f.write(pretty_xml)
 
 
 @task
@@ -462,6 +563,7 @@ def develop(c):
         c.run("git init")
         c.run("ln -sf devel.yaml docker-compose.yml")
         write_code_workspace_file(c)
+        generate_idea_conf(c)
         c.run("pre-commit install")
 
 
@@ -477,6 +579,7 @@ def git_aggregate(c):
             env=UID_ENV,
         )
     write_code_workspace_file(c)
+    generate_idea_conf(c)
     for git_folder in SRC_PATH.glob("*/.git/.."):
         action = (
             "install"


### PR DESCRIPTION
Scaffolding support for debugging with pydevd/pycharm.
Depends on https://github.com/Tecnativa/doodba/pull/665
How to test: clone/update a template with the option `--vcs-ref=dck-imp-pydev_debugger`
Example:
`copier update --vcs-ref=dck-imp-pydev_debugger --trust -f`
Change dockerfile ref to
`ghcr.io/tecnativa/doodba:${ODOO_VERSION}-pr-665-test-onbuild`

Add pydevd-pycharm to the image, you should use a version compatible with your pycharm version (you can see on the menu to create a remote debugging task)

I recommend adding it to an ignored dependencies file ignored (ex 0-pip-local.txt), because it shouldn't end up in prod and 2 different developers may have different pycharm versions.

Rebuild the image, run git aggregate and then start with --pycharm
```
invoke img-build git-aggregate
invoke start --pydevd

```
@tecnativa TT56757