### PR TITLE
[IMP] Ignore .idea/ conf files, generated by pycharm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 /.venv
 /doodba.*.code-workspace
 /src
+.idea/*
 
 # Project-specific docker configurations
 /.docker/


### PR DESCRIPTION
Exclude PyCharm project config directory by adding .idea/ to .gitignore.