### PR TITLE
[IMP] Remove version in compose yaml files.

### DIFF
--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -1,5 +1,4 @@
 {% import "_macros.jinja" as macros -%}
-version: "2.4"
 
 services:
   odoo:

--- a/devel.yaml.jinja
+++ b/devel.yaml.jinja
@@ -7,7 +7,6 @@
   "www.googleapis.com",
   "www.gravatar.com",
 ) -%}
-version: "2.4"
 
 services:
   odoo_proxy:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -258,7 +258,6 @@ volumes:
 <summary>Traefik v2 docker compose</summary>
 
 ```yaml
-version: "2.4"
 services:
   proxy:
     image: traefik:2.4
@@ -351,7 +350,6 @@ volumes:
 <summary>Traefik v3 docker compose</summary>
 
 ```yaml
-version: "2.4"
 services:
   proxy:
     image: traefik:3.0

--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -6,7 +6,6 @@
 {%- import "_traefik3_labels.yml.jinja" as traefik3_labels -%}
 {%- import "_traefik3_paths_labels.yml.jinja" as traefik3_labels_2 -%}
 {%- set _key = traefik2_labels.key(project_name, odoo_version, "prod") -%}
-version: "2.4"
 
 services:
   odoo:

--- a/setup-devel.yaml.jinja
+++ b/setup-devel.yaml.jinja
@@ -8,7 +8,6 @@
 #
 #   git clean -ffd
 
-version: "2.4"
 
 services:
   odoo:

--- a/test.yaml.jinja
+++ b/test.yaml.jinja
@@ -3,7 +3,6 @@
 {%- import "_traefik2_labels.yml.jinja" as traefik2_labels -%}
 {%- import "_traefik3_labels.yml.jinja" as traefik3_labels -%}
 {%- set _key = traefik2_labels.key(project_name, odoo_version, "test") -%}
-version: "2.4"
 
 services:
   odoo:


### PR DESCRIPTION
In compose files, the version key is obsolete and does nothing, this romves it to avoid the warning.
Official compose spec document: https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-top-level-element-obsolete
Issue about it: https://github.com/docker/compose/issues/11628