### PR TITLE
feat(odoo_listdb_staging): explicit option for exposing DB list in staging only

### DIFF
--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -20,7 +20,6 @@ services:
       PGDATABASE: &dbname {{ postgres_dbname }}
       PGUSER: &dbuser "{{ postgres_username }}"
       PROXY_MODE: "{% if odoo_proxy %}true{% else %}false{% endif %}"
-      LIST_DB: "{{ odoo_listdb | tojson }}"
     tty: true
     volumes:
       - filestore:/var/lib/odoo:z

--- a/copier.yml
+++ b/copier.yml
@@ -162,7 +162,13 @@ odoo_listdb:
   default: false
   type: bool
   help: >-
-    Do you want to list databases publicly?
+    Do you want to list databases publicly in the production environment?
+
+odoo_listdb_staging:
+  default: "{{ odoo_listdb }}"
+  type: bool
+  help: >-
+    Do you want to list databases publicly in the staging environment?
 
 odoo_oci_image:
   type: str

--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -24,6 +24,7 @@ services:
       DB_FILTER: "{{ odoo_dbfilter | replace('$', '$$') }}"
       DOODBA_ENVIRONMENT: "${DOODBA_ENVIRONMENT-prod}"
       INITIAL_LANG: "{{ odoo_initial_lang }}"
+      LIST_DB: "{{ odoo_listdb | tojson }}"
       {%- if odoo_version >= 16.0 %}
       ODOO_BUS_PUBLIC_SAMESITE_WS: 1
       {%- endif %}

--- a/test.yaml.jinja
+++ b/test.yaml.jinja
@@ -15,6 +15,7 @@ services:
       - .docker/db-access.env
     environment:
       DOODBA_ENVIRONMENT: "${DOODBA_ENVIRONMENT-test}"
+      LIST_DB: "{{ odoo_listdb_staging | tojson }}"
       {%- if odoo_version >= 16.0 %}
       ODOO_BUS_PUBLIC_SAMESITE_WS: 1
       {%- endif %}


### PR DESCRIPTION
This can be helpful if you want to have a single production environment
while having multiple databases for testing in staging.

@moduon MT-10847
