### PR TITLE
fix(ruff): modernize rules

### DIFF
--- a/.ruff.toml.jinja
+++ b/.ruff.toml.jinja
@@ -15,16 +15,16 @@ exclude = ["setup/*"]
 [format]
 exclude = ["setup/*"]
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "__init__.py" = ["F401", "I001"]  # ignore unused and unsorted imports in __init__.py
 "__manifest__.py" = ["B018"]  # useless expression
 
-[isort]
+[lint.isort]
 section-order = ["future", "standard-library", "third-party", "odoo", "odoo-addons", "first-party", "local-folder"]
 
-[isort.sections]
+[lint.isort.sections]
 "odoo" = ["odoo"]
 "odoo-addons" = ["odoo.addons"]
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 16


### PR DESCRIPTION
Modern Ruff versions yield this warning when scanning a doodba project:

  ``` warning: The top-level linter settings are deprecated in favour of
  their counterparts in the `lint` section. Please update the following
  options in `.ruff.toml`: - 'isort' -> 'lint.isort' - 'mccabe' ->
  'lint.mccabe' - 'per-file-ignores' -> 'lint.per-file-ignores' ```

@moduon MT-10479
