### PR TITLE
[IMP] Use INITIAL_LANG on resetdb to choose lang on devel

### DIFF
--- a/devel.yaml.jinja
+++ b/devel.yaml.jinja
@@ -42,6 +42,7 @@ services:
         COMPILE: "false"
     environment:
       DOODBA_ENVIRONMENT: "${DOODBA_ENVIRONMENT-devel}"
+      INITIAL_LANG: "{{ odoo_initial_lang }}"
       LIST_DB: "true"
       DEBUGPY_ENABLE: "${DOODBA_DEBUGPY_ENABLE:-0}"
       PGDATABASE: &dbname devel

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -1006,8 +1006,10 @@ def resetdb(
             warn=True,
             pty=True,
         )
+        lang = os.getenv("INITIAL_LANG")
+        lang_opt = f" --lang {lang}" if lang else ""
         c.run(
-            f"{_run} click-odoo-initdb -n {dbname} -m {modules}",
+            f"{_run} click-odoo-initdb -n {dbname} -m {modules}{lang_opt}",
             env=UID_ENV,
             pty=True,
         )


### PR DESCRIPTION
`resetdb` now forwards the `INITIAL_LANG` environment variable to `click-odoo-initdb`, ensuring new databases load the specified language, and devel.yaml.jinja exposes `INITIAL_LANG` so developers can set their preferred locale directly in the compose file.

Fixes [this issue](https://github.com/Tecnativa/doodba/issues/668) 

CC @Tecnativa TT57094