### PR TITLE
[IMP] Add allowed paths

### DIFF
--- a/_traefik1_paths_labels.yml.jinja
+++ b/_traefik1_paths_labels.yml.jinja
@@ -48,7 +48,7 @@
 {%- endmacro %}
 
 {#- Basic labels for a single router #}
-{%- macro router(domain_group, key, suffix, rule=none, service=none, middlewares=()) %}
+{%- macro router(domain_group, key, suffix, rule=none, service=none, middlewares=(), priority=none) %}
       traefik.http.routers.{{ key }}-{{ suffix }}-{{ domain_group.loop.index0 }}.rule:
         {{ rule|default(domains_rule(domain_group), true) }}
       traefik.http.routers.{{ key }}-{{ suffix }}-{{ domain_group.loop.index0 }}.service:
@@ -60,6 +60,10 @@
       {%- if middlewares %}
       traefik.http.routers.{{ key }}-{{ suffix }}-{{ domain_group.loop.index0 }}.middlewares:
         {{ key }}-{{ middlewares|sort|join(", %s-" % key) }}
+      {%- endif %}
+
+      {%- if priority %}
+      traefik.http.routers.{{ key }}-{{ suffix }}-{{ domain_group.loop.index0 }}.priority: {{ priority }}
       {%- endif %}
 
       {%- if domain_group.cert_resolver %}
@@ -75,7 +79,7 @@
       {#- Create TLS-only router;
          HACK https://github.com/containous/traefik/issues/7235 #}
       {%- else %}
-      {{- router(domain_group, key, "%s-secure" % suffix, rule, service, middlewares) }}
+      {{- router(domain_group, key, "%s-secure" % suffix, rule, service, middlewares, priority) }}
       {%- endif %}
 
       {%- endif %}
@@ -101,7 +105,7 @@
 {%- endmacro %}
 
 {%- macro odoo(domain_groups_list, cidr_whitelist, key, odoo_version,
-               paths_without_crawlers, project_name) %}
+               paths_without_crawlers, paths_with_crawlers, project_name) %}
       {#- Service #}
       traefik.http.services.{{ key }}-main.loadbalancer.server.port: 8069
       traefik.http.services.{{ key }}-longpolling.loadbalancer.server.port: 8072
@@ -132,6 +136,7 @@
             "compress",
             "redirect-%d" % domain_group.loop.index0,
           ],
+          priority=10,
         )
       }}
       {%- else %}
@@ -148,6 +153,7 @@
             "buffering",
             "compress",
           ],
+          priority=1,
         )
       }}
       {%- endif %}
@@ -163,6 +169,7 @@
           rule="%s && %s" % (domains_rule(domain_group), longpolling_route),
           service="longpolling",
           middlewares=_ns.basic_middlewares,
+          priority=10,
         )
       }}
       {%- endif %}
@@ -183,6 +190,25 @@
             "compress",
             "forbid-crawlers",
           ],
+          priority=10,
+        )
+      }}
+      {%- endif %}
+      {%- if paths_with_crawlers and not domain_group.path_prefixes %}
+      {{-
+        router(
+          domain_group=domain_group,
+          key=key,
+          suffix="allowedCrawlers",
+          rule="%s && %s" % (
+            domains_rule(domain_group),
+            path_prefix_rule(paths_with_crawlers),
+          ),
+          middlewares=_ns.basic_middlewares + [
+            "buffering",
+            "compress",
+          ],
+          priority=100,
         )
       }}
       {%- endif %}

--- a/_traefik2_labels.yml.jinja
+++ b/_traefik2_labels.yml.jinja
@@ -48,7 +48,7 @@
 {%- endmacro %}
 
 {#- Basic labels for a single router #}
-{%- macro router(domain_group, key, suffix, rule=none, service=none, middlewares=()) %}
+{%- macro router(domain_group, key, suffix, rule=none, service=none, middlewares=(), priority=none) %}
       traefik.http.routers.{{ key }}-{{ suffix }}-{{ domain_group.loop.index0 }}.rule:
         {{ rule|default(domains_rule(domain_group), true) }}
       traefik.http.routers.{{ key }}-{{ suffix }}-{{ domain_group.loop.index0 }}.service:
@@ -60,6 +60,10 @@
       {%- if middlewares %}
       traefik.http.routers.{{ key }}-{{ suffix }}-{{ domain_group.loop.index0 }}.middlewares:
         {{ key }}-{{ middlewares|sort|join(", %s-" % key) }}
+      {%- endif %}
+
+      {%- if priority %}
+      traefik.http.routers.{{ key }}-{{ suffix }}-{{ domain_group.loop.index0 }}.priority: {{ priority }}
       {%- endif %}
 
       {%- if domain_group.cert_resolver %}
@@ -75,7 +79,7 @@
       {#- Create TLS-only router;
          HACK https://github.com/containous/traefik/issues/7235 #}
       {%- else %}
-      {{- router(domain_group, key, "%s-secure" % suffix, rule, service, middlewares) }}
+      {{- router(domain_group, key, "%s-secure" % suffix, rule, service, middlewares, priority) }}
       {%- endif %}
 
       {%- endif %}
@@ -106,7 +110,7 @@
 {%- endmacro %}
 
 {%- macro odoo(domain_groups_list, cidr_whitelist, key, odoo_version,
-               paths_without_crawlers, project_name) %}
+               paths_without_crawlers, paths_with_crawlers, project_name) %}
       {%- if odoo_version >= 16%}
       {{- custom_ws_middleware(key) }}
       {%- endif %}
@@ -140,6 +144,7 @@
             "compress",
             "redirect-%d" % domain_group.loop.index0,
           ],
+          priority=10,
         )
       }}
       {%- else %}
@@ -156,6 +161,7 @@
             "buffering",
             "compress",
           ],
+          priority=1,
         )
       }}
       {%- endif %}
@@ -176,6 +182,7 @@
           rule="%s && %s" % (domains_rule(domain_group), longpolling_route),
           service="longpolling",
           middlewares=ws_middlewares,
+          priority=10,
         )
       }}
       {%- endif %}
@@ -196,6 +203,25 @@
             "compress",
             "forbid-crawlers",
           ],
+          priority=10,
+        )
+      }}
+      {%- endif %}
+      {%- if paths_with_crawlers and not domain_group.path_prefixes %}
+      {{-
+        router(
+          domain_group=domain_group,
+          key=key,
+          suffix="allowedCrawlers",
+          rule="%s && %s" % (
+            domains_rule(domain_group),
+            path_prefix_rule(paths_with_crawlers),
+          ),
+          middlewares=_ns.basic_middlewares + [
+            "buffering",
+            "compress",
+          ],
+          priority=100,
         )
       }}
       {%- endif %}

--- a/_traefik3_paths_labels.yml.jinja
+++ b/_traefik3_paths_labels.yml.jinja
@@ -57,7 +57,7 @@
 {%- endmacro %}
 
 {#- Basic labels for a single router #}
-{%- macro router(domain_group, key, suffix, rule=none, service=none, middlewares=()) %}
+{%- macro router(domain_group, key, suffix, rule=none, service=none, middlewares=(), priority=none) %}
       traefik.http.routers.{{ key }}-{{ suffix }}-{{ domain_group.loop.index0 }}.rule:
         {{ rule|default(domains_rule(domain_group), true) }}
       traefik.http.routers.{{ key }}-{{ suffix }}-{{ domain_group.loop.index0 }}.service:
@@ -69,6 +69,9 @@
       {%- if middlewares %}
       traefik.http.routers.{{ key }}-{{ suffix }}-{{ domain_group.loop.index0 }}.middlewares:
         {{ key }}-{{ middlewares|sort|join(", %s-" % key) }}
+      {%- endif %}
+      {%- if priority %}
+      traefik.http.routers.{{ key }}-{{ suffix }}-{{ domain_group.loop.index0 }}.priority: {{ priority }}
       {%- endif %}
 
       {%- if domain_group.cert_resolver %}
@@ -84,7 +87,7 @@
       {#- Create TLS-only router;
          HACK https://github.com/containous/traefik/issues/7235 #}
       {%- else %}
-      {{- router(domain_group, key, "%s-secure" % suffix, rule, service, middlewares) }}
+      {{- router(domain_group, key, "%s-secure" % suffix, rule, service, middlewares, priority) }}
       {%- endif %}
 
       {%- endif %}
@@ -115,7 +118,7 @@
 {%- endmacro %}
 
 {%- macro odoo(domain_groups_list, cidr_whitelist, key, odoo_version,
-               paths_without_crawlers, project_name) %}
+               paths_without_crawlers, paths_with_crawlers, project_name) %}
       {%- if odoo_version >= 16%}
       {{- custom_ws_middleware(key) }}
       {%- endif %}
@@ -148,6 +151,7 @@
             "compress",
             "redirect-%d" % domain_group.loop.index0,
           ],
+          priority=10,
         )
       }}
       {%- else %}
@@ -164,6 +168,7 @@
             "buffering",
             "compress",
           ],
+          priority=1,
         )
       }}
       {%- endif %}
@@ -184,6 +189,7 @@
           rule="%s && %s" % (domains_rule(domain_group), longpolling_route),
           service="longpolling",
           middlewares=ws_middlewares,
+          priority=10,
         )
       }}
       {%- endif %}
@@ -204,6 +210,27 @@
             "compress",
             "forbid-crawlers",
           ],
+          priority=10,
+        )
+      }}
+      {%- endif %}
+
+      {#- Allowed crawlers router #}
+      {%- if paths_with_crawlers and not domain_group.path_prefixes %}
+      {{-
+        router(
+          domain_group=domain_group,
+          key=key,
+          suffix="allowedCrawlers",
+          rule="%s && %s" % (
+            domains_rule(domain_group),
+            path_prefix_rule(paths_with_crawlers),
+          ),
+          middlewares=_ns.basic_middlewares + [
+            "buffering",
+            "compress",
+          ],
+            priority=100,
         )
       }}
       {%- endif %}

--- a/copier.yml
+++ b/copier.yml
@@ -351,6 +351,17 @@ paths_without_crawlers:
     💡 We will convert this to `Path` rules. Check valid syntax in
     https://docs.traefik.io/routing/routers/#rule
 
+paths_with_crawlers:
+  multiline: true
+  default:
+    - /web/image/website
+  help: >-
+    Tell me the list of paths which where you want to allow crawlers and might get
+    blocked by the `paths_without_crawlers` setting.
+
+    💡 We will convert this to `Path` rules. Check valid syntax in
+    https://docs.traefik.io/routing/routers/#rule
+
 cidr_whitelist:
   multiline: true
   default: null

--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -60,6 +60,7 @@ services:
               _key,
               odoo_version,
               paths_without_crawlers,
+              paths_with_crawlers,
               project_name,
             ) }}
       {%- elif traefik_version == 2 -%}
@@ -69,6 +70,7 @@ services:
               _key,
               odoo_version,
               paths_without_crawlers,
+              paths_with_crawlers,
               project_name,
             ) }}
       {%- else -%}
@@ -78,6 +80,7 @@ services:
               _key,
               odoo_version,
               paths_without_crawlers,
+              paths_with_crawlers,
               project_name,
             ) }}
       {%- endif %}

--- a/test.yaml.jinja
+++ b/test.yaml.jinja
@@ -49,6 +49,7 @@ services:
         _key,
         odoo_version,
         ["/"],
+        [],
         project_name,
       ) }}
     {%- endif %}


### PR DESCRIPTION
This might allow to index images like favicon.

We are still testing if this fixes this issue:

<img width="163" height="279" alt="image" src="https://github.com/user-attachments/assets/0174d32d-b849-49f4-ba63-984e0fe09dc4" />

As you can see, the favicon is not processed properly. The same happens in Bing.

The only reason we found is that favicon is related to web/image/website/1/favicon and traefik adds the x-robot-tag noindex.

Right now it is promising as Google Search Console App detected the favicon (before it had the same image that we find in google search). However, as we have not managed to reindex the main page, we are not 100% sure that it fixes it.

:crossed_fingers: 