### PR TITLE
[IMP] Add --dev=access for Odoo 19 in devel environment

### DIFF
--- a/devel.yaml.jinja
+++ b/devel.yaml.jinja
@@ -73,8 +73,10 @@ services:
       - --workers=0
       {%- if odoo_version == 9 %}
       - --dev
-      {%- elif odoo_version >= 10 %}
+      {%- elif odoo_version >= 10 and odoo_version < 19 %}
       - --dev=reload,qweb,werkzeug,xml
+      {%- else %}
+      - --dev=reload,qweb,werkzeug,xml,access
       {%- endif %}
 
   {% if postgres_version -%}


### PR DESCRIPTION
Adds the --dev=access option to the development YAML for Odoo 19 to facilitate debugging of access rights and permissions during development.