### PR TITLE
[FIX] make postgres_version default depend on odoo_version

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -541,7 +541,9 @@ cidr_whitelist:
     ⚠️ It must be a list. And this is only supported if you deploy with Traefik 2+.
 
 postgres_version:
-  default: "18"
+  default: >-
+    {% if odoo_version <= 12.0 %}13 {% elif odoo_version <= 14.0 %}16 {% else %}18{%
+    endif %}
   help: >-
     Which PostgreSQL version do you want to deploy? (Recommended: for new instances
     always use the latest version. Version 9.6 has no backup support.)


### PR DESCRIPTION
Copier validates defaults before asking, so the previous default "17"
triggered our validator when selecting Odoo 12 (which disallows >13),
failing the run before the question was shown.

Fixes https://github.com/Tecnativa/doodba-copier-template/issues/564