### PR TITLE
[FIX] Remove jingtrang for Odoo >=16 due to pkg_resources deprecation

### DIFF
--- a/odoo/custom/dependencies/pip.txt.jinja
+++ b/odoo/custom/dependencies/pip.txt.jinja
@@ -4,6 +4,6 @@ unidecode{% if odoo_version < 11.0 %}<1.3.0{% endif %}
 {% if odoo_version < 11.0 -%}
 pathlib
 {% endif -%}
-{% if odoo_version >= 13.0 -%}
+{% if 13.0 <= odoo_version < 16.0 -%}
 jingtrang
 {% endif -%}


### PR DESCRIPTION
This removes the jingtrang dependency for Odoo >=16 to avoid warnings caused by
the pkg_resources deprecation in newer setuptools. Keeping it could lead to
runtime errors in future builds, and Odoo works fine without it.

CC @Tecnativa TT58417