### PR TITLE
Update README.md for modern pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Install non-python apps with your distro's recommended package manager. The reco
 way to install Python CLI apps is [pipx](https://pipxproject.github.io/pipx/):
 
 ```bash
-python3 -m pip install --user pipx
+python3 -m pip install --break-system-packages --user pipx
 pipx install copier
 pipx install invoke
 pipx install pre-commit


### PR DESCRIPTION
Modern pip needs `--break-system-packages` to install in a "clean" (almost) ubuntu.

<details>

<summary>Output of `python3 -m pip install --user pipx` in Ubuntu 24.04.3 LTS</summary>

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

</details>