### PR TITLE
[IMP] use https instead of gh prefix for copier copy cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pipx ensurepath
 Once you installed everything, you can now use Copier to copy this template:
 
 ```bash
-copier copy gh:Tecnativa/doodba-copier-template ~/path/to/your/subproject
+copier copy https://github.com/Tecnativa/doodba-copier-template ~/path/to/your/subproject
 ```
 
 Copier will ask you a lot of questions. Answer them to properly generate the template.


### PR DESCRIPTION
The address `​gh:Tecnativa/doodba-copier-template`​ in `.copier-answers.yml` is not supported by renovate: 

See: https://github.com/renovatebot/renovate/pull/29215 

As such, renovate fails to update the project, and gives the following warning in the dependency dashboard:

⚠️ Warning
Renovate failed to look up the following dependencies: Failed to look up git-tags package gh:Tecnativa/doodba-copier-template.

<img width="570" height="130" alt="image" src="https://github.com/user-attachments/assets/18cdb0be-5114-406b-b02a-8220e350d942" />

