### PR TITLE
[FIX] remove invalid z option from docker volumes

### DIFF
--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -22,7 +22,7 @@ services:
       PROXY_MODE: "{% if odoo_proxy %}true{% else %}false{% endif %}"
     tty: true
     volumes:
-      - filestore:/var/lib/odoo:z
+      - filestore:/var/lib/odoo
     {%- if odoo_proxy == "traefik" %}
     labels:
       traefik.backend.buffering.retryExpression: IsNetworkError() && Attempts() < 5
@@ -41,7 +41,7 @@ services:
       CONF_EXTRA: |
         work_mem = 512MB
     volumes:
-      - db:/var/lib/postgresql/data:z
+      - db:/var/lib/postgresql/data
   {%- endif %}
 
   smtpfake:
@@ -53,11 +53,11 @@ services:
     hostname: "smtp.{{ smtp_canonical_default }}"
     stop_grace_period: 1m
     volumes:
-      - mailconfig:/tmp/docker-mailserver:z
-      - maildata:/var/mail:z
-      - maillogs:/var/log/mail:z
-      - maillogssupervisord:/var/log/supervisor:z
-      - mailstate:/var/mail-state:z
+      - mailconfig:/tmp/docker-mailserver
+      - maildata:/var/mail
+      - maillogs:/var/log/mail
+      - maillogssupervisord:/var/log/supervisor
+      - mailstate:/var/mail-state
     cap_add:
       - SYS_PTRACE
     environment:
@@ -110,6 +110,6 @@ services:
       {%- endif %}
       TZ: "{{ backup_tz }}"
     volumes:
-      - backup_cache:/root:z
-      - filestore:/mnt/backup/src/odoo:z
+      - backup_cache:/root
+      - filestore:/mnt/backup/src/odoo
   {%- endif %}

--- a/test.yaml.jinja
+++ b/test.yaml.jinja
@@ -139,7 +139,7 @@ services:
       {%- endcall %}
       {%- endif %}
     volumes:
-      - "smtpconf:/etc/mailhog:ro,z"
+      - "smtpconf:/etc/mailhog:ro"
     entrypoint: [sh, -c]
     command:
       - test -r /etc/mailhog/auth && export MH_AUTH_FILE=/etc/mailhog/auth; exec MailHog


### PR DESCRIPTION
The :z option is only valid for bind mounts, not docker volumes. So it does not do anything, and it leads to the following warning from compose

```
WARN[0000] mount of type `volume` should not define `bind` option
```

It's not immediately clear from the documentation:

https://docs.docker.com/reference/compose-file/services/#short-syntax-5

but you can find a similar fix in other similar projects, e.g. https://github.com/cookiecutter/cookiecutter-django/pull/3981