### PR TITLE
[IMP] add .env file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 
 # Project-specific docker configurations
 /.docker/
+/.env


### PR DESCRIPTION
This file is automatically read by docker compose and its values are injected in compose just like regular environment variables set in the shell. It can be a more convenient alternative to setting the variable in the shell itself, and allows for more flexible scripting

For example, we use it to set the exact image name that's currently deployed, and to easily revert to a previous image

in `common.yaml`

```yaml
services:
  odoo:
    image: path/to/image:${COMMIT_HASH-latest}
```

in `.env`:
```sh
COMMIT_HASH='123abc'
```

Let me know if I should add a test similar to `test_dotdocker_ignore_content`

