### PR TITLE
Revert "[IMP] add .env file to gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@
 
 # Project-specific docker configurations
 /.docker/
-/.env


### PR DESCRIPTION
This PR reverts ignoring .env by default.
Since .env is Docker Compose’s default environment file and can be part of a project’s reproducible configuration, ignoring it at template level may lead to diverging local setups.
Projects that need to ignore .env for any reason can still do so by adjusting their own .gitignore after generating the project from DCT.