### PR TITLE
[FIX] Docker compose version is obsolete

### DIFF
--- a/common.yaml.jinja
+++ b/common.yaml.jinja
@@ -1,6 +1,8 @@
 {% import "_macros.jinja" as macros -%}
+{% if compose_version == "v1" %}
 version: "2.4"
 
+{% endif %}
 services:
   odoo:
     {%- if odoo_oci_image %}

--- a/copier.yml
+++ b/copier.yml
@@ -138,6 +138,18 @@ traefik_version:
     v2.4: 2
     v3.0: 3
 
+compose_version:
+  type: str
+  help: >-
+    Indicate the Docker Compose version.
+
+    Used to generate the Docker Compose files so that they are compatible with the
+    indicated version.
+  default: "{{ 'v1' if _copier_operation == 'update' else 'v2+'}}"
+  choices:
+    - v1
+    - v2+
+
 odoo_initial_lang:
   default: en_US
   type: str

--- a/devel.yaml.jinja
+++ b/devel.yaml.jinja
@@ -7,8 +7,10 @@
   "www.googleapis.com",
   "www.gravatar.com",
 ) -%}
+{% if compose_version == "v1" %}
 version: "2.4"
 
+{% endif %}
 services:
   odoo_proxy:
     image: ghcr.io/tecnativa/docker-whitelist:latest

--- a/prod.yaml.jinja
+++ b/prod.yaml.jinja
@@ -6,8 +6,10 @@
 {%- import "_traefik3_labels.yml.jinja" as traefik3_labels -%}
 {%- import "_traefik3_paths_labels.yml.jinja" as traefik3_labels_2 -%}
 {%- set _key = traefik2_labels.key(project_name, odoo_version, "prod") -%}
+{% if compose_version == "v1" %}
 version: "2.4"
 
+{% endif %}
 services:
   odoo:
     extends:

--- a/setup-devel.yaml.jinja
+++ b/setup-devel.yaml.jinja
@@ -8,8 +8,10 @@
 #
 #   git clean -ffd
 
+{% if compose_version == "v1" %}
 version: "2.4"
 
+{% endif %}
 services:
   odoo:
     {%- if odoo_oci_image %}

--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -73,9 +73,10 @@ def _override_docker_command(service, command, file, orig_file=None):
     else:
         docker_compose_file_version = "2.4"
     docker_config = {
-        "version": docker_compose_file_version,
         "services": {service: {"command": command}},
     }
+    if not docker_compose_v2 and docker_compose_file_version:
+        docker_config["version"] = docker_compose_file_version
     docker_config_yaml = yaml.dump(docker_config)
     file.write(docker_config_yaml)
     file.flush()

--- a/test.yaml.jinja
+++ b/test.yaml.jinja
@@ -3,8 +3,10 @@
 {%- import "_traefik2_labels.yml.jinja" as traefik2_labels -%}
 {%- import "_traefik3_labels.yml.jinja" as traefik3_labels -%}
 {%- set _key = traefik2_labels.key(project_name, odoo_version, "test") -%}
+{% if compose_version == "v1" %}
 version: "2.4"
 
+{% endif %}
 services:
   odoo:
     extends:


### PR DESCRIPTION
Fix https://github.com/Tecnativa/doodba-copier-template/issues/541.

Without this change, the following warning is shown when executing a compose file:
> the attribute "version" is obsolete, it will be ignored, please remove it to avoid potential confusion