### PR TITLE
Allow to configure backup password

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -815,3 +815,18 @@ backup_passphrase:
     restore backups.
 
     Which will be your backups passphrase?
+
+backup_backend_password:
+  secret: true
+  type: str
+  default: example-backup-backend-password
+  when: *backup_present
+  help: >-
+    ⚠️ This password is critical for security, so keep it safe. You will need it to
+    restore backups.
+
+    This password is supported by most duplicity backends (like SFTP) which are password
+    capable. If your backend uses it, setting it here will safely store it in an
+    environment variable, that is more secure than setting it in the backend url.
+
+    Which will be your backups password?

--- a/template/.docker/{% if backup_dst %}backup.env{% endif %}.jinja
+++ b/template/.docker/{% if backup_dst %}backup.env{% endif %}.jinja
@@ -6,3 +6,6 @@ AWS_ACCESS_KEY_ID={{ backup_aws_access_key_id }}
 AWS_SECRET_ACCESS_KEY={{ backup_aws_secret_access_key }}
 {%- endif %}
 PASSPHRASE={{ backup_passphrase }}
+{%- if backup_backend_password %}
+BACKEND_PASSWORD={{ backup_backend_password }}
+{%- endif %}


### PR DESCRIPTION
Allow to configure the password for backups in a question.
The variable `BACKEND_PASSWORD` is mentioned in duplicity's documentation https://duplicity.gitlab.io/stable/duplicity.1.html#environment-variables:

> **BACKEND_PASSWORD**, _FTP_PASSWORD (deprecated)_
> 
>  Supported by most backends which are password capable. More secure than setting it in the backend url (which might be readable in the operating systems process listing to other users on the same machine).
