### PR TITLE
[FIX] _override_docker_command version fallback for debug mode

### DIFF
--- a/tasks_downstream.py
+++ b/tasks_downstream.py
@@ -68,11 +68,12 @@ _logger = getLogger(__name__)
 
 def _override_docker_command(service, command, file, orig_file=None):
     # Read config from main file
+    docker_compose_file_version = None
     if orig_file:
         with open(orig_file) as fd:
             orig_docker_config = yaml.safe_load(fd.read())
             docker_compose_file_version = orig_docker_config.get("version")
-    else:
+    if not docker_compose_file_version:
         docker_compose_file_version = "2.4"
     docker_config = {
         "services": {service: {"command": command}},


### PR DESCRIPTION
When using debugpy (VSCode debug), _override_docker_command fails on modern Docker Compose v2+ where devel.yaml no longer contains the version key.

The else clause only set the "2.4" fallback when orig_file was None. If the file existed but lacked version, docker_compose_file_version remained undefined, breaking debug mode.