### PR TITLE
[IMP] Sync oca submodule to latest commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,16 +69,16 @@ jobs:
             python-version: "3.10"
             traefik-version: 3
           - odoo-version: "15.0"
-            python-version: "3.9"
+            python-version: "3.10"
             traefik-version: 2
           - odoo-version: "15.0"
-            python-version: "3.9"
+            python-version: "3.10"
             traefik-version: 3
           - odoo-version: "14.0"
-            python-version: "3.9"
+            python-version: "3.10"
             traefik-version: 3
           - odoo-version: "13.0"
-            python-version: "3.9"
+            python-version: "3.10"
             traefik-version: 3
 
     steps:

--- a/template/.pre-commit-config.yaml.jinja
+++ b/template/.pre-commit-config.yaml.jinja
@@ -2,29 +2,23 @@
    and it's designed only for Odoo 13.0+, so we design our own version, which
    should be as close as possible to MQT's -#}
 
-{#- This namespace holds repo versions #}
-{%- set proj_rev = namespace() %}
-{%- set proj_rev.ruff = "v0.1.3" %}
-{%- set proj_rev.pre_commit_hooks = "v4.5.0" %}
-{%- set proj_rev.odoo_pre_commit_hooks = "v0.0.29" %}
-{%- set proj_rev.refurb = "v2.3.1" %}
-{%- if odoo_version < 16 %}
-  {%- set proj_rev.pylint_odoo = "v8.0.0" %}
-{%- elif odoo_version < 17 %}
-  {%- set proj_rev.pylint_odoo = "v8.0.20" %}
-{%- elif odoo_version < 18 %}
-  {%- set proj_rev.pylint_odoo = "v9.0.4" %}
-{%- elif odoo_version < 19 %}
-  {%- set proj_rev.pylint_odoo = "v9.1.3" %}
-  {%- set proj_rev.ruff = "v0.6.8" %}
-  {%- set proj_rev.pre_commit_hooks = "v4.6.0" %}
-  {%- set proj_rev.odoo_pre_commit_hooks = "v0.0.33" %}
+{#- Upstream doesn't support v13 and lower the same way as higher versions, so
+  we use a diferent config #}
+{%- if odoo_version < 14 %}
+  {%- set repo_rev = namespace() %}
+  {%- set repo_rev.pylint_odoo = "v8.0.0" %}
 {%- else %}
-  {%- set proj_rev.pre_commit_hooks = "v6.0.0" %}
-  {%- set proj_rev.pylint_odoo = "v9.3.15" %}
-  {%- set proj_rev.odoo_pre_commit_hooks = "v0.1.6" %}
-  {%- set proj_rev.ruff = "v0.13.0" %}
-{%- endif -%}
+  {%- from 'vendor/oca-addons-repo-template/src/.pre-commit-config.yaml.jinja' import repo_rev with context %}
+{%- endif %}
+{#- All Verions #}
+{%- set repo_rev.refurb = "v2.3.1" %}
+{#- Apllies to v17 and below #}
+{%- if odoo_version < 18 %}
+  {%- set repo_rev.ruff = "v0.1.3" %}
+  {%- set repo_rev.pre_commit_hooks = "v4.5.0" %}
+  {%- set repo_rev.odoo_pre_commit_hooks = "v0.0.29" %}
+{%- endif%}
+
 
 exclude: |
   (?x)
@@ -60,7 +54,7 @@ repos:
           - odoo/custom/src/private
   {% if odoo_version >= 14 -%}
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
-    rev: {{ proj_rev.odoo_pre_commit_hooks }}
+    rev: {{ repo_rev.odoo_pre_commit_hooks }}
     hooks:
       - id: oca-checks-odoo-module
       - id: oca-checks-po
@@ -69,13 +63,13 @@ repos:
   {% if odoo_version >= 13 -%}
   {% if use_refurb -%}
   - repo: https://github.com/dosisod/refurb
-    rev: {{ proj_rev.refurb }}
+    rev: {{ repo_rev.refurb }}
     hooks:
       - id: refurb
         exclude: migrations/.*
   {% endif -%}
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: {{ proj_rev.ruff }}
+    rev: {{ repo_rev.ruff }}
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -124,7 +118,7 @@ repos:
           - prettier@2.7.1
           - "@prettier/plugin-xml@v2.2.0"
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: {{ proj_rev.pre_commit_hooks }}
+    rev: {{ repo_rev.pre_commit_hooks }}
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -148,7 +142,7 @@ repos:
       - id: mixed-line-ending
         args: ["--fix=lf"]
   - repo: https://github.com/OCA/pylint-odoo
-    rev: {{ proj_rev.pylint_odoo }}
+    rev: {{ repo_rev.pylint_odoo }}
     hooks:
       - id: pylint_odoo
         name: pylint with optional checks


### PR DESCRIPTION
Updates OCA repo template to latest commit, and uses it to obtain pre-commit config versions.
Also, bump python used to test legacy versions in ci as pre-commit wasn't behaving.
TT58388