### PR TITLE
[IMP] Allow env file in proxy

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -14,6 +14,7 @@ _skip_if_exists:
   - odoo/custom/src/private/*/
   - odoo/custom/src/repos.yaml
   - odoo/custom/ssh/*
+  - .docker/proxy.env
 
 _tasks:
   - invoke after-update

--- a/template/.docker/proxy.env
+++ b/template/.docker/proxy.env
@@ -1,0 +1,3 @@
+# Add to this file ALLOWED_HOSTS vars for the proxy.
+# Example usage: symlink this to a global file with the following content:
+# ALLOWED_HOSTS_GLOBAL="example.com google.com"

--- a/template/migration.yaml.jinja
+++ b/template/migration.yaml.jinja
@@ -1,2 +1,3 @@
 {%- set domain_spec = domains_migration -%}
+{%- set whitelisted_hosts_test = [] -%}
 {% include "template/test.yaml.jinja" with context %}

--- a/template/test.yaml.jinja
+++ b/template/test.yaml.jinja
@@ -175,6 +175,8 @@ services:
       DOCKER_PRIMARY_SERVICE: "odoo"
       ALLOWED_HOSTS: >-
         {{ _whitelisted_hosts_test|join(' ') }}
+    env_file:
+      - .docker/proxy.env
 
   proxy_general:
     image: ghcr.io/tecnativa/docker-whitelist-gateway-service:edge
@@ -192,6 +194,8 @@ services:
       MODE_RUN: "gateway"
       ALLOWED_HOSTS: >-
         {{ _whitelisted_hosts_test|join(' ') }}
+    env_file:
+      - .docker/proxy.env
   {% endif %}
 networks:
   default:


### PR DESCRIPTION
This PR allows using an env file in the proxy configuration.
The intended usage is to symlink that file to a global file containing shared ALLOWED_HOSTS for the proxy.
TT59918 @Tecnativa