### PR TITLE
[FIX] pg_isready

### DIFF
--- a/template/devel.yaml.jinja
+++ b/template/devel.yaml.jinja
@@ -92,7 +92,7 @@ services:
       POSTGRES_DB: *dbname
       POSTGRES_PASSWORD: odoopassword
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -q -U $$POSTGRES_USER"]
+      test: ["CMD-SHELL", "pg_isready -q -d $$POSTGRES_DB -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
The pg_isready healthcheck was missing the -d flag, causing it to probe a database named after the user (odoo) instead of the actual database (devel). This flooded the logs with FATAL: database "odoo" does not exist every 5 seconds. Adding -d $$POSTGRES_DB makes the check target the correct database

cc @pedrobaeza 