### PR TITLE
[IMP] Wait for Odoo to be healthy before starting odoo_proxy

### DIFF
--- a/template/devel.yaml.jinja
+++ b/template/devel.yaml.jinja
@@ -8,7 +8,8 @@ services:
   odoo_proxy:
     image: ghcr.io/tecnativa/docker-whitelist:latest
     depends_on:
-      - odoo
+      odoo:
+        condition: service_healthy
     networks: &public
       default:
       public:
@@ -56,17 +57,31 @@ services:
       - ./odoo/custom:/opt/odoo/custom:ro,z
       - ./odoo/auto:/opt/odoo/auto:rw,z
     depends_on:
-      - db
-      - smtp
-      - wdb
+      db:
+        condition: service_healthy
+      smtp:
+        condition: service_started
+      wdb:
+        condition: service_started
       {%- if whitelisted_hosts %}
-      - proxy_general
+      proxy_general:
+        condition: service_started
       {%- endif %}
     {%- if whitelisted_hosts %}
     networks:
       default:
       whitelist:
     {%- endif %}
+    healthcheck:
+      {%- if odoo_version >= 14 %}
+      test: ["CMD-SHELL", "curl -sf http://localhost:8069/web/health || exit 1"]
+      {%- else %}
+      test: ["CMD-SHELL", "curl -sf http://localhost:8069/web/database/selector || exit 1"]
+      {%- endif %}
+      start_period: 30s
+      interval: 10s
+      timeout: 5s
+      retries: 5
     command:
       - odoo
       - --limit-memory-soft=0


### PR DESCRIPTION
### Summary
Added a healthcheck to the odoo service in devel.yaml.jinja using the /web/health endpoint `(Odoo ≥ 14)` or `/web/database/selector (Odoo < 14)`, with a 30s start_period to account for slow module loading
Updated odoo_proxy to use condition: service_healthy on odoo, so the proxy only starts after Odoo is fully ready
Updated odoo to use condition: service_healthy on db, consistent with the healthcheck already added in #601
### Motivation
Previously, odoo_proxy started as soon as the odoo container existed, immediately trying to forward connections while Odoo was still loading modules. This flooded the logs with Connection refused errors for 1–2 minutes on every startup. The proxy now waits for Odoo to actually be ready before accepting connections.