### PR TITLE
[IMP] disable postgres JIT

### DIFF
--- a/template/common.yaml.jinja
+++ b/template/common.yaml.jinja
@@ -43,6 +43,9 @@ services:
       PGDATA: "/var/lib/postgresql/data"
       CONF_EXTRA: |
         work_mem = 512MB
+        {%- if postgres_version|int > 11 %}
+        jit = off
+        {%- endif %}
     volumes:
       - db:/var/lib/postgresql/data
   {%- endif %}


### PR DESCRIPTION
Odoo does not benefit from JIT (normal usage), so it's best to disable it by default.

Enabled by default in 12: https://www.postgresql.org/docs/12/runtime-config-query.html#GUC-JIT
Disabled by default in 19: https://www.postgresql.org/docs/19/runtime-config-query.html#GUC-JIT

More info: https://www.cybrosys.com/research-and-development/postgres/how-postgresql-jit-affects-odoo-performance-benchmarks