### PR TITLE
[IMP] tasks.py: Fix img-pull with private doodba image.

### DIFF
--- a/template/tasks_downstream.py
+++ b/template/tasks_downstream.py
@@ -669,10 +669,13 @@ def img_build(c, pull=True):
 
 
 @task()
-def img_pull(c):
+def img_pull(c, ignore_buildable=True):
     """Pull docker images."""
+    cmd = DOCKER_COMPOSE_CMD + " pull"
+    if ignore_buildable:
+        cmd += " --ignore-buildable"
     with c.cd(str(PROJECT_ROOT)):
-        c.run(DOCKER_COMPOSE_CMD + " pull", pty=True)
+        c.run(cmd, pty=True)
 
 
 @task()


### PR DESCRIPTION
Defaults img-pull to only pull non buildable images to avoid the error when trying to pull a doodba image on a private registry.

@tecnativa