### PR TITLE
[IMP] resetdb: Allow to create DB without demo

### DIFF
--- a/template/tasks_downstream.py
+++ b/template/tasks_downstream.py
@@ -1135,6 +1135,7 @@ def stop(c, purge=False):
         " Default: True",
         "dependencies": "Install only the dependencies of the specified addons."
         "Default: False",
+        "demo": "Create the DB with demo data. Default: True.",
     },
 )
 def resetdb(
@@ -1147,6 +1148,7 @@ def resetdb(
     dbname="devel",
     populate=True,
     dependencies=False,
+    demo=True,
 ):
     """Reset the specified database with the specified modules.
 
@@ -1170,8 +1172,9 @@ def resetdb(
         )
         lang = os.getenv("INITIAL_LANG")
         lang_opt = f" --lang {lang}" if lang else ""
+        demo_opt = " --demo" if demo else " --no-demo"
         c.run(
-            f"{_run} click-odoo-initdb -n {dbname} -m {modules}{lang_opt}",
+            f"{_run} click-odoo-initdb -n {dbname} -m {modules}{lang_opt}{demo_opt}",
             env=UID_ENV,
             pty=True,
         )


### PR DESCRIPTION
I had the same query as https://github.com/Tecnativa/doodba-copier-template/discussions/512: long story short, 
```sh
export DOODBA_WITHOUT_DEMO=all; inv resetdb
```
is still creating a DB with demo data.

The proposed solution
```
export DOODBA_WITHOUT_DEMO=all; docker compose run --rm odoo -i base
```
works fine, but `resetdb`'s parameters and `click-odoo-initdb`'s cache are very helpful so it would be nice to use them to create a no-demo DB.

One use-case I'm facing a lot recently is migrations: in order to check that the migration of a module works correctly, I have to create a DB with only that module and no demo in the initial version because some demo data is breaking the migration.

Note that `click-odoo-initdb` is smart enough to inject the demo option in the cache checksum (https://github.com/acsone/click-odoo-contrib/blob/0be44caf281a8b7993844d15709d3636b3b9f119/click_odoo_contrib/initdb.py#L134) so there is no conflict between cached DBs with/without demo data.

I see there are environment variables `DOODBA_WITHOUT_DEMO` and `WITHOUT_DEMO` to manage demo data, but using `click-odoo-initdb`'s flag looks to me like the most simple/direct approach.
Please let me know what you think!