### PR TITLE
[FIX] Use a common pg version reference table and deprecate v9.6

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -95,6 +95,39 @@ _migrations:
         - "{{ _copier_conf.answers_file }}"
         - "9.6.0"
         - "--varname=whitelisted_hosts_test"
+pg_per_odoo:
+  when: False
+  type: yaml
+  # Odoo 11-13 supports pg 9.6 but that version is not supported by the backup service
+  # and is necessary to be able to perform all tests
+  default:
+    11.0:
+      oldest: "10"
+      latest: "13"
+    12.0:
+      oldest: "10"
+      latest: "13"
+    13.0:
+      oldest: "10"
+      latest: "16"
+    14.0:
+      oldest: "10"
+      latest: "16"
+    15.0:
+      oldest: "10"
+      latest: "17"
+    16.0:
+      oldest: "12"
+      latest: "18"
+    17.0:
+      oldest: "12"
+      latest: "18"
+    18.0:
+      oldest: "12"
+      latest: "18"
+    19.0:
+      oldest: "12"
+      latest: "18"
 
 # Questions for the user
 odoo_version:
@@ -542,14 +575,12 @@ cidr_whitelist:
 
 postgres_version:
   default: >-
-    {% if odoo_version <= 12.0 %}13 {% elif odoo_version <= 14.0 %}16 {% else %}18{%
-    endif %}
+    {{ pg_per_odoo[odoo_version]['latest'] }}
   help: >-
     Which PostgreSQL version do you want to deploy? (Recommended: for new instances
-    always use the latest version. Version 9.6 has no backup support.)
+    always use the latest version.)
   choices:
     I will use an external PostgreSQL server: ""
-    "9.6": "9.6"
     "10": "10"
     "11": "11"
     "12": "12"
@@ -560,13 +591,10 @@ postgres_version:
     "17": "17"
     "18": "18"
   validator: >-
-    {% if postgres_version|int > 0 %} {% if (odoo_version >= 16.0 and
-    postgres_version|int < 12) or (odoo_version >= 14.0 and postgres_version|int < 10)
-    %}  The postgres version is too low for the selected Odoo version. {% elif
-    odoo_version <= 12.0 and postgres_version|int > 13 %}  The postgres version is too
-    high for the selected Odoo version. {% elif odoo_version <= 14.0 and
-    postgres_version|int > 16 %} The postgres version is too high for the selected Odoo
-    version. {% endif %} {% endif %}
+    {% if not (pg_per_odoo[odoo_version]['oldest'] | int <= (postgres_version | int) <=
+    pg_per_odoo[odoo_version]['latest']|int) %} Version must be between {{
+    pg_per_odoo[odoo_version]['oldest'] }} and {{ pg_per_odoo[odoo_version]['latest']
+    }}. {% endif %}
 
 postgres_username:
   type: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,53 +29,15 @@ SUPPORTED_ODOO_VERSIONS = tuple(
     v for v in ALL_ODOO_VERSIONS if v >= OLDEST_SUPPORTED_ODOO_VERSION
 )
 LAST_ODOO_VERSION = max(SUPPORTED_ODOO_VERSIONS)
-SELECTED_ODOO_VERSIONS = (
-    frozenset(map(float, os.environ.get("SELECTED_ODOO_VERSIONS", "").split()))
-    or ALL_ODOO_VERSIONS
-)
-PRERELEASE_ODOO_VERSIONS = {19.0}
+SELECTED_ODOO_VERSIONS = frozenset(
+    map(float, os.environ.get("SELECTED_ODOO_VERSIONS", "").split())
+) or [ALL_ODOO_VERSIONS[-1]]
+PRERELEASE_ODOO_VERSIONS = {20.0}
 
 # Postgres versions
 ALL_PSQL_VERSIONS = tuple(COPIER_SETTINGS["postgres_version"]["choices"])
 LATEST_PSQL_VER = ALL_PSQL_VERSIONS[-1]
-DBVER_PER_ODOO = {
-    11.0: {
-        "oldest": "10",  # Odoo supports 9.6, but that version is not supported by the backup service and is necessary to be able to perform all tests
-        "latest": "13",  # DB Authentication method limitation
-    },
-    12.0: {
-        "oldest": "10",  # Odoo supports 9.6, but that version is not supported by the backup service and is necessary to be able to perform all tests
-        "latest": "13",
-    },
-    13.0: {
-        "oldest": "10",  # Odoo supports 9.6, but that version is not supported by the backup service and is necessary to be able to perform all tests
-        "latest": "16",
-    },
-    14.0: {
-        "oldest": "10",
-        "latest": "16",
-    },
-    15.0: {
-        "oldest": "10",
-        "latest": "17",
-    },
-    16.0: {
-        "oldest": "12",
-        "latest": LATEST_PSQL_VER,
-    },
-    17.0: {
-        "oldest": "12",
-        "latest": LATEST_PSQL_VER,
-    },
-    18.0: {
-        "oldest": "12",
-        "latest": LATEST_PSQL_VER,
-    },
-    19.0: {
-        "oldest": "12",
-        "latest": LATEST_PSQL_VER,
-    },
-}
+DBVER_PER_ODOO = COPIER_SETTINGS["pg_per_odoo"]["default"]
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
We use a fake copier question to store the pg per odoo versions in a single place, it won't end up in the answers file as it has when: False.
Deprecate v9.6 as it reachedd EOL more than 4 years ago and the backup service doesn't support it.
Fixes #655 
@tecnativa @pedrobaeza @patrick-rademacher-mm