### PR TITLE
[FIX] tasks: resetdb follows demo settings in devel.yaml

### DIFF
--- a/template/devel.yaml.jinja
+++ b/template/devel.yaml.jinja
@@ -51,7 +51,7 @@ services:
       {%- endif %}
       WDB_WEB_PORT: "${PORT_PREFIX:-{{ macros.version_major(odoo_version) -}} }984"
       # To avoid installing demo data export DOODBA_WITHOUT_DEMO=all
-      WITHOUT_DEMO: "${DOODBA_WITHOUT_DEMO-false}"
+      WITHOUT_DEMO: "${DOODBA_WITHOUT_DEMO-{{ 'true' if odoo_version >= 19 else 'false'}}}"
     volumes:
       - ./odoo/custom:/opt/odoo/custom:ro,z
       - ./odoo/auto:/opt/odoo/auto:rw,z

--- a/template/tasks_downstream.py
+++ b/template/tasks_downstream.py
@@ -13,6 +13,7 @@ import re
 import shutil
 import stat
 import subprocess
+import sys
 import tempfile
 import time
 import xml.etree.ElementTree as ET
@@ -1138,7 +1139,10 @@ def stop(c, purge=False):
         " Default: True",
         "dependencies": "Install only the dependencies of the specified addons."
         "Default: False",
-        "demo": "Create the DB with demo data. Default: True.",
+        "demo": (
+            "Create the DB with demo data. "
+            "Default: follow what is defined in the compose file."
+        ),
     },
 )
 def resetdb(
@@ -1175,6 +1179,14 @@ def resetdb(
         )
         lang = os.getenv("INITIAL_LANG")
         lang_opt = f" --lang {lang}" if lang else ""
+        if "--demo" not in sys.argv and "--no-demo" not in sys.argv:
+            config = yaml.safe_load(
+                c.run(f"{DOCKER_COMPOSE_CMD} config", hide=True).stdout
+            )
+            without_demo = config["services"]["odoo"]["environment"][
+                "WITHOUT_DEMO"
+            ].lower()
+            demo = without_demo in ["all", "true", "1"]
         demo_opt = " --demo" if demo else " --no-demo"
         c.run(
             f"{_run} click-odoo-initdb -n {dbname} -m {modules}{lang_opt}{demo_opt}",
@@ -1182,7 +1194,7 @@ def resetdb(
             pty=True,
         )
     if populate and ODOO_VERSION < 11:
-        _logger.warn(
+        _logger.warning(
             f"Skipping populate task as it is not available in v{ODOO_VERSION}"
         )
         populate = False


### PR DESCRIPTION
Now, invoke resetdb will follow whatever is defined in the current compose file when demo/no-demo is not specified.